### PR TITLE
embedding fraction implementation

### DIFF
--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -145,7 +145,8 @@ class MosaicGPT(nn.Module):
         super().__init__()
         assert cfg.name == 'mosaic_gpt', f'Tried to build MosaicGPT model with cfg.name={cfg.name}'
         self.cfg = cfg
-        # CogView and GLM-130B papers both report this helping with stabilizing training
+        # CogView (https://arxiv.org/abs/2105.13290) and GLM-130B (https://arxiv.org/abs/2210.02414)
+        # both report this helping with stabilizing training
         self.embedding_fraction = cfg.get("embedding_fraction", 1)
         assert 0 < self.embedding_fraction <= 1, "model.embedding_fraction must be between 0 (exclusive) and 1 (inclusive)!"
         self.transformer = nn.ModuleDict(
@@ -193,6 +194,7 @@ class MosaicGPT(nn.Module):
             x = self.transformer.emb_drop(tok_emb + pos_emb)  # type: ignore
         else:
             x = tok_emb + pos_emb
+            # this implementation is proposed on page 7 of the GLM-130B paper https://arxiv.org/abs/2210.02414
             x = self.transformer.emb_drop(
                 x * self.embedding_fraction + x.detach() * (1 - self.embedding_fraction)
             )

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -194,7 +194,7 @@ class MosaicGPT(nn.Module):
         else:
             x = tok_emb + pos_emb
             x = self.transformer.emb_drop(
-                x = x * self.embedding_fraction + x.detach() * (1 - self.embedding_fraction)
+                x * self.embedding_fraction + x.detach() * (1 - self.embedding_fraction)
             )
         for block in self.transformer.blocks:  # type: ignore
             x = block(x, key_padding_mask)

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -146,7 +146,8 @@ class MosaicGPT(nn.Module):
         assert cfg.name == 'mosaic_gpt', f'Tried to build MosaicGPT model with cfg.name={cfg.name}'
         self.cfg = cfg
         # CogView and GLM-130B papers both report this helping with stabilizing training
-        self.embedding_fraction = cfg.embedding_fraction if 0 < cfg.embedding_fraction < 1 else 1
+        self.embedding_fraction = cfg.get("embedding_fraction", 1)
+        assert 0 < self.embedding_fraction <= 1, "model.embedding_fraction must be between 0 (exclusive) and 1 (inclusive)!"
         self.transformer = nn.ModuleDict(
             dict(
                 wte=nn.Embedding(cfg.vocab_size, cfg.d_model,


### PR DESCRIPTION
Implement embedding fraction per CogView and GLM-130B. To use, model config should look like (last line is new, the rest is a normal config):

```yaml
# Model
model:
  name: mosaic_gpt
  device: meta
  tokenizer_name: *tokenizer_name
  d_model: 2048
  n_heads: 16 # Modified 24->16 so that d_head == 128 to statisfy FlashAttention
  n_layers: 24
  mlp_ratio: 4
  max_seq_len: *max_seq_len
  vocab_size: 50257
  init_std: 0.02
  attn_pdrop: 0.0
  resid_pdrop: 0.0
  emb_pdrop: 0.0
  attn_impl: flash
  embedding_fraction: 0.1  # This is the value GLM-130B used
```

I noticed that a lot of config values were mandatory, but I made this default to 1 since it is not common.