### PR TITLE
Updates for Composer v0.12.0 and Streaming v0.2.0

### DIFF
--- a/bert/main.py
+++ b/bert/main.py
@@ -45,6 +45,8 @@ def build_algorithm(name, kwargs):
         return algorithms.FusedLayerNorm(**kwargs)
     elif name == 'gated_linear_units':
         return algorithms.GatedLinearUnits(**kwargs)
+    elif name == 'gradient_clipping':
+        return algorithms.GradientClipping(**kwargs)
     else:
         raise ValueError(f'Not sure how to build algorithm: {name}')
 
@@ -177,7 +179,6 @@ def main(cfg):
         callbacks=callbacks,
         precision=cfg.precision,
         device=cfg.get('device', None),
-        grad_clip_norm=cfg.grad_clip_norm,
         grad_accum=cfg.get('grad_accum', 'auto'),
         save_folder=cfg.get('save_folder', None),
         save_interval=cfg.get('save_interval', '1000ba'),

--- a/bert/src/data_c4.py
+++ b/bert/src/data_c4.py
@@ -148,6 +148,8 @@ def build_c4_dataloader(cfg: DictConfig, device_batch_size: int):
                           local=cfg.dataset.local,
                           shuffle=cfg.dataset.shuffle,
                           predownload=cfg.dataset.predownload,
+                          download_retry=cfg.dataset.download_retry,
+                          download_timeout=cfg.dataset.download_timeout,
                           tokenizer_name=cfg.dataset.tokenizer_name,
                           max_seq_len=cfg.dataset.max_seq_len,
                           group_method=cfg.dataset.group_method,

--- a/bert/src/data_c4.py
+++ b/bert/src/data_c4.py
@@ -148,8 +148,6 @@ def build_c4_dataloader(cfg: DictConfig, device_batch_size: int):
                           local=cfg.dataset.local,
                           shuffle=cfg.dataset.shuffle,
                           predownload=cfg.dataset.predownload,
-                          download_retry=cfg.dataset.download_retry,
-                          download_timeout=cfg.dataset.download_timeout,
                           tokenizer_name=cfg.dataset.tokenizer_name,
                           max_seq_len=cfg.dataset.max_seq_len,
                           group_method=cfg.dataset.group_method,

--- a/bert/src/data_c4.py
+++ b/bert/src/data_c4.py
@@ -11,11 +11,11 @@ from typing import Any, Dict, Iterator, Optional
 import transformers
 from omegaconf import DictConfig
 from omegaconf import OmegaConf as om
-from streaming import Dataset
+from streaming import StreamingDataset
 from torch.utils.data import DataLoader
 
 
-class StreamingC4(Dataset):
+class StreamingC4(StreamingDataset):
     """Colossal Cleaned Common Crawl dataset using streaming datasets V2.
 
     Args:
@@ -23,12 +23,12 @@ class StreamingC4(Dataset):
         local (str): Local filesystem directory where dataset is cached during operation.
         split (str): The dataset split to use, either 'train' or 'val'.
         shuffle (bool): Whether to shuffle the samples in this dataset.
-        prefetch (int): Target number of samples remaining to prefetch while iterating.
+        predownload (int): Target number of samples remaining to prefetch while iterating.
         tokenizer_name (str): The name of the HuggingFace tokenizer to use to tokenize samples.
         max_seq_len (int): The max sequence length of each token sample.
         group_method (str): How to group text samples into token samples. Supports 'truncate' or 'concat'.
-        retry (int): Number of download re-attempts before giving up. Default: 2.
-        timeout (float): How long to wait for shard to download before raising an exception. Default: 120 sec.
+        download_retry (int): Number of download re-attempts before giving up. Default: 2.
+        download_timeout (float): How long to wait for shard to download before raising an exception. Default: 120 sec.
         batch_size (Optional[int]): Hint batch_size that will be used on each device's DataLoader. Default: ``None``.
     """
 
@@ -37,12 +37,12 @@ class StreamingC4(Dataset):
                  local: str,
                  split: str,
                  shuffle: bool,
-                 prefetch: int,
+                 predownload: int,
                  tokenizer_name: str,
                  max_seq_len: int,
                  group_method: str = 'truncate',
-                 retry: int = 2,
-                 timeout: float = 120,
+                 download_retry: int = 2,
+                 download_timeout: float = 120,
                  batch_size: Optional[int] = None):
         # Validation
         if split not in ['train', 'val']:
@@ -58,10 +58,10 @@ class StreamingC4(Dataset):
                          local=local,
                          split=split,
                          shuffle=shuffle,
-                         prefetch=prefetch,
+                         predownload=predownload,
                          keep_zip=False,
-                         retry=retry,
-                         timeout=timeout,
+                         download_retry=download_retry,
+                         download_timeout=download_timeout,
                          hash=None,
                          batch_size=batch_size)
         self.tokenizer_name = tokenizer_name
@@ -147,7 +147,7 @@ def build_c4_dataloader(cfg: DictConfig, device_batch_size: int):
                           remote=cfg.dataset.remote,
                           local=cfg.dataset.local,
                           shuffle=cfg.dataset.shuffle,
-                          prefetch=cfg.dataset.prefetch,
+                          predownload=cfg.dataset.predownload,
                           tokenizer_name=cfg.dataset.tokenizer_name,
                           max_seq_len=cfg.dataset.max_seq_len,
                           group_method=cfg.dataset.group_method,
@@ -188,7 +188,7 @@ if __name__ == '__main__':
             'local': local,
             'split': 'val',
             'shuffle': True,
-            'prefetch': 1000,
+            'predownload': 1000,
             'tokenizer_name': 'bert-base-uncased',
             'max_seq_len': 32,
             'group_method': 'truncate',

--- a/bert/src/data_c4.py
+++ b/bert/src/data_c4.py
@@ -62,7 +62,7 @@ class StreamingC4(StreamingDataset):
                          keep_zip=False,
                          download_retry=download_retry,
                          download_timeout=download_timeout,
-                         hash=None,
+                         validate_hash=None,
                          batch_size=batch_size)
         self.tokenizer_name = tokenizer_name
         self.max_seq_len = max_seq_len

--- a/bert/yamls/main/hf-bert-base-uncased.yaml
+++ b/bert/yamls/main/hf-bert-base-uncased.yaml
@@ -27,7 +27,7 @@ train_loader:
     remote: *data_remote
     local: *data_local
     split: train
-    prefetch: 1_000_000
+    predownload: 1_000_000
     tokenizer_name: *tokenizer_name
     max_seq_len: *max_seq_len
     group_method: truncate
@@ -46,7 +46,7 @@ eval_loader:
     remote: *data_remote
     local: *data_local
     split: val
-    prefetch: 1000
+    predownload: 1000
     tokenizer_name: *tokenizer_name
     max_seq_len: *max_seq_len
     group_method: truncate

--- a/bert/yamls/main/hf-bert-base-uncased.yaml
+++ b/bert/yamls/main/hf-bert-base-uncased.yaml
@@ -77,7 +77,6 @@ optimizer:
 max_duration: 286720000sp # Subsample the training data for ~275M samples
 eval_interval: 2000ba
 global_train_batch_size: 4096
-grad_clip_norm: -1.0
 
 # System
 seed: 17

--- a/bert/yamls/main/mcloud_run.yaml
+++ b/bert/yamls/main/mcloud_run.yaml
@@ -102,7 +102,6 @@ parameters:
   max_duration: 286720000sp # Subsample the training data for ~275M samples
   eval_interval: 2000ba
   global_train_batch_size: 4096
-  grad_clip_norm: -1.0
 
   # System
   seed: 17

--- a/bert/yamls/main/mcloud_run.yaml
+++ b/bert/yamls/main/mcloud_run.yaml
@@ -49,7 +49,7 @@ parameters:
       remote: *data_remote
       local: *data_local
       split: train
-      prefetch: 1_000_000
+      predownload: 1_000_000
       tokenizer_name: *tokenizer_name
       max_seq_len: *max_seq_len
       group_method: truncate
@@ -68,7 +68,7 @@ parameters:
       remote: *data_remote
       local: *data_local
       split: val
-      prefetch: 1000
+      predownload: 1000
       tokenizer_name: *tokenizer_name
       max_seq_len: *max_seq_len
       group_method: truncate

--- a/bert/yamls/main/mosaic-bert-base-uncased.yaml
+++ b/bert/yamls/main/mosaic-bert-base-uncased.yaml
@@ -26,7 +26,7 @@ train_loader:
     remote: *data_remote
     local: *data_local
     split: train
-    prefetch: 1_000_000
+    predownload: 1_000_000
     tokenizer_name: *tokenizer_name
     max_seq_len: *max_seq_len
     group_method: truncate
@@ -45,7 +45,7 @@ eval_loader:
     remote: *data_remote
     local: *data_local
     split: val
-    prefetch: 1000
+    predownload: 1000
     tokenizer_name: *tokenizer_name
     max_seq_len: *max_seq_len
     group_method: truncate

--- a/bert/yamls/main/mosaic-bert-base-uncased.yaml
+++ b/bert/yamls/main/mosaic-bert-base-uncased.yaml
@@ -79,7 +79,6 @@ algorithms:
 max_duration: 286720000sp # Subsample the training data for ~275M samples
 eval_interval: 2000ba
 global_train_batch_size: 4096
-grad_clip_norm: -1.0
 
 # System
 seed: 17

--- a/bert/yamls/test/main.yaml
+++ b/bert/yamls/test/main.yaml
@@ -75,8 +75,6 @@ optimizer:
   eps: 1.0e-08
   weight_decay: 0.0
 
-grad_clip_norm: -1.0
-
 # Training duration and evaluation frequency
 max_duration: 10ba
 eval_interval: 10ba

--- a/bert/yamls/test/main.yaml
+++ b/bert/yamls/test/main.yaml
@@ -29,7 +29,7 @@ train_loader:
     tokenizer_name: *tokenizer_name
     max_seq_len: *max_seq_len
     group_method: truncate
-    prefetch: 1000
+    predownload: 1000
     shuffle: true
     mlm_probability: *mlm_probability
   drop_last: true
@@ -48,7 +48,7 @@ eval_loader:
     tokenizer_name: *tokenizer_name
     max_seq_len: *max_seq_len
     group_method: truncate
-    prefetch: 1000
+    predownload: 1000
     shuffle: false
     mlm_probability: *mlm_probability
   drop_last: false

--- a/resnet/data.py
+++ b/resnet/data.py
@@ -10,7 +10,7 @@ import torch
 from composer.core import DataSpec
 from composer.datasets.utils import NormalizationFn, pil_image_collate
 from composer.utils import dist
-from streaming import Dataset
+from streaming import StreamingDataset
 from torch.utils.data import DataLoader
 from torchvision import transforms
 from torchvision.datasets import ImageFolder, VisionDataset
@@ -21,7 +21,7 @@ IMAGENET_CHANNEL_MEAN = (0.485 * 255, 0.456 * 255, 0.406 * 255)
 IMAGENET_CHANNEL_STD = (0.229 * 255, 0.224 * 255, 0.225 * 255)
 
 
-class StreamingImageNet(Dataset, VisionDataset):
+class StreamingImageNet(StreamingDataset, VisionDataset):
     """ImageNet streaming dataset based on PyTorch's VisionDataset.
 
     Args:
@@ -31,10 +31,10 @@ class StreamingImageNet(Dataset, VisionDataset):
         shuffle (bool): Whether to iterate over the samples in randomized order.
         transform (callable, optional): A function/transform that takes in an image and returns a transformed version.
             Default: ``None``.
-        prefetch (int, optional): Target number of samples remaining to prefetch while iterating.
+        predownload (int, optional): Target number of samples remaining to predownload while iterating.
             Default: ``100_000``.
-        retry (int, optional): Number of download re-attempts before giving up. Defaults to ``2``.
-        timeout (float, optional): Number of seconds to wait for a shard to download before raising
+        download_retry (int, optional): Number of download re-attempts before giving up. Defaults to ``2``.
+        download_timeout (float, optional): Number of seconds to wait for a shard to download before raising
             an exception. Default: 120 seconds.
         batch_size (int, optional): The batch size that will be used on each device's DataLoader.
             Default: ``None``.
@@ -46,9 +46,9 @@ class StreamingImageNet(Dataset, VisionDataset):
                  split: Optional[str],
                  shuffle: bool,
                  transform: Optional[Callable] = None,
-                 prefetch: Optional[int] = 100_000,
-                 retry: Optional[int] = 2,
-                 timeout: Optional[float] = 120,
+                 predownload: Optional[int] = 100_000,
+                 download_retry: Optional[int] = 2,
+                 download_timeout: Optional[float] = 120,
                  batch_size: Optional[int] = None) -> None:
 
         if split not in ['train', 'val']:
@@ -61,11 +61,13 @@ class StreamingImageNet(Dataset, VisionDataset):
                          local=local,
                          split=split,
                          shuffle=shuffle,
-                         prefetch=prefetch,
+                         predownload=predownload,
                          keep_zip=False,
-                         retry=retry,
-                         timeout=timeout,
-                         hash=None,
+                         download_retry=download_retry,
+                         download_timeout=download_timeout,
+                         validate_hash=None,
+                         shuffle_seed=None,
+                         num_canonical_nodes=None,
                          batch_size=batch_size)
 
     def __getitem__(self, idx: int) -> Any:

--- a/resnet/main.py
+++ b/resnet/main.py
@@ -24,8 +24,7 @@ from omegaconf import DictConfig, OmegaConf
 def build_logger(name: str, kwargs: Dict):
     if name == 'progress_bar':
         return ProgressBarLogger(
-            progress_bar=kwargs.get('progress_bar', True),
-            log_to_console=kwargs.get('log_to_console', True),
+            log_traces=kwargs.get('log_traces', False),
         )
     elif name == 'wandb':
         return WandBLogger(**kwargs)

--- a/resnet/main.py
+++ b/resnet/main.py
@@ -185,6 +185,8 @@ def main(config):
     trainer = Trainer(
         run_name=config.run_name,
         progress_bar=config.progress_bar,
+        log_to_console=config.log_to_console,
+        console_log_interval=config.console_log_interval,
         model=composer_model,
         train_dataloader=train_dataspec,
         eval_dataloader=eval_dataspec,

--- a/resnet/main.py
+++ b/resnet/main.py
@@ -13,7 +13,7 @@ from composer.algorithms import (EMA, SAM, BlurPool, ChannelsLast, ColOut,
                                  LabelSmoothing, MixUp, ProgressiveResizing,
                                  RandAugment, StochasticDepth)
 from composer.callbacks import LRMonitor, MemoryMonitor, SpeedMonitor
-from composer.loggers import ProgressBarLogger, WandBLogger
+from composer.loggers import WandBLogger
 from composer.optim import CosineAnnealingWithWarmupScheduler, DecoupledSGDW
 from composer.utils import dist
 from data import build_imagenet_dataspec
@@ -22,11 +22,7 @@ from omegaconf import DictConfig, OmegaConf
 
 
 def build_logger(name: str, kwargs: Dict):
-    if name == 'progress_bar':
-        return ProgressBarLogger(
-            log_traces=kwargs.get('log_traces', False),
-        )
-    elif name == 'wandb':
+    if name == 'wandb':
         return WandBLogger(**kwargs)
     else:
         raise ValueError(f'Not sure how to build logger: {name}')
@@ -188,6 +184,7 @@ def main(config):
     precision = 'amp' if device == 'gpu' else 'fp32'  # Mixed precision for fast training when using a GPU
     trainer = Trainer(
         run_name=config.run_name,
+        progress_bar=config.progress_bar,
         model=composer_model,
         train_dataloader=train_dataspec,
         eval_dataloader=eval_dataspec,

--- a/resnet/requirements.txt
+++ b/resnet/requirements.txt
@@ -1,2 +1,2 @@
-mosaicml[streaming,wandb]==0.11.0
+mosaicml[streaming,wandb]==0.12.0
 omegaconf

--- a/resnet/yamls/mcloud_run.yaml
+++ b/resnet/yamls/mcloud_run.yaml
@@ -2,7 +2,7 @@ run_name: resnet_example
 cluster:       # Name of the cluster to use for this run
 gpu_type: a100_40gb # Type of GPU to use
 gpu_num: 8  # Number of GPUs to use
-image: mosaicml/pytorch:1.12.1_cu116-python3.9-ubuntu20.04
+image: mosaicml/pytorch:1.13.0_cu117-python3.10-ubuntu20.04
 integrations:
 - integration_type: git_repo
   git_repo: mosaicml/examples
@@ -19,6 +19,9 @@ parameters:
   seed: 17                   # Random seed
   max_duration: 90ep         # Duration to train specified as a Time string
   grad_accum: auto           # Amount of gradient accumulation, 'auto' means Composer will choose the optimal value
+  progress_bar: false        # Prints TQDM logging progress bar if true
+  log_to_console: true       # Prints metrics logging statements if true
+  console_log_interval: 1ep  # Frequency of metric logging statements
 
   # Model
   model:
@@ -56,7 +59,6 @@ parameters:
     alpha_f: 0.0  # Base learning rate multiplier to decay to
 
   loggers:
-    progress_bar: {}
     # wandb:     # Uncomment and fill below arguments to use WandB logger
     #   entity:  # Name of WandB entity, usually username or organization name
     #   project: # Name of WandB project

--- a/resnet/yamls/resnet50.yaml
+++ b/resnet/yamls/resnet50.yaml
@@ -3,6 +3,9 @@ is_train: true             # Trains the model if true, otherwise runs evaluation
 seed: 17                   # Random seed
 max_duration: 90ep         # Duration to train specified as a Time string
 grad_accum: auto           # Amount of gradient accumulation, 'auto' means Composer will choose the optimal value
+progress_bar: false        # Prints TQDM logging progress bar if true
+log_to_console: true       # Prints metrics logging statements if true
+console_log_interval: 1ep  # Frequency of metric logging statements
 
 # Model
 model:
@@ -40,7 +43,6 @@ scheduler:
   alpha_f: 0.0  # Base learning rate multiplier to decay to
 
 loggers:
-  progress_bar: {}
   # wandb:     # Uncomment and fill below arguments to use WandB logger
   #   entity:  # Name of WandB entity, usually username or organization name
   #   project: # Name of WandB project


### PR DESCRIPTION
This PR queues up several updates required for API changes that come with Composer v0.12.0 and Streaming v0.2.0.  

Following benchmarks have been updated:
- Resnet
   - Updated `StreamingImagenet` for Streaming v0.2.0
   - Removed `ProgressBarLogger` callback, switched to using new Trainer args
   - Updated YAMLs to use PyTorch 1.13 Docker images
- HF BERT-base
   - Updated `StreamingC4` for Streaming v0.2.0
   - Removed `ProgressBarLogger` callback, switched to using new Trainer args
   - Removed deprecated `grad_clip_norm` Trainer arg
   - Updated YAMLs to use PyTorch 1.13 Docker images

Note: Changes to the LLM benchmarks are queued up in PR #50 and PR #51