### PR TITLE
Triton&Flashibi in examples/llm

### DIFF
--- a/bert/src/flash_attn_triton.py
+++ b/bert/src/flash_attn_triton.py
@@ -800,6 +800,9 @@ def _flash_attn_forward(q, k, v, bias=None, causal=False, softmax_scale=None):
             bias = repeat(bias, '1 h ... -> b h ...', b=batch)
         elif bias.shape[:2] == (batch, 1):
             bias = repeat(bias, 'b 1 ... -> b h ...', h=nheads)
+        elif bias.shape[:2] == (1, 1):
+            bias = repeat(bias, '1 h ... -> b h ...', b=batch)
+            bias = repeat(bias, 'b 1 ... -> b h ...', h=nheads)
         assert bias.shape[:2] == (
             batch, nheads
         ), f'First 2 dimensions of bias must be broadcastible to (batch, nheads) = ({batch, nheads}). Bias has shape: {bias.shape}'

--- a/bert/src/flash_attn_triton.py
+++ b/bert/src/flash_attn_triton.py
@@ -802,7 +802,7 @@ def _flash_attn_forward(q, k, v, bias=None, causal=False, softmax_scale=None):
             bias = repeat(bias, 'b 1 ... -> b h ...', h=nheads)
         assert bias.shape[:2] == (
             batch, nheads
-        ), f'First 2 dimensions of bias must be broadcastible to (batch, nheads). Bias has shape: {bias.shape}'
+        ), f'First 2 dimensions of bias must be broadcastible to (batch, nheads) = ({batch, nheads}). Bias has shape: {bias.shape}'
     assert bias is not None  # for type checking
     bias_strides = (bias.stride(0), bias.stride(1),
                     bias.stride(2)) if has_bias else (0, 0, 0)

--- a/bert/src/flash_attn_triton.py
+++ b/bert/src/flash_attn_triton.py
@@ -931,9 +931,12 @@ def _flash_attn_backward(do,
             bias = repeat(bias, '1 h ... -> b h ...', b=batch)
         elif bias.shape[:2] == (batch, 1):
             bias = repeat(bias, 'b 1 ... -> b h ...', h=nheads)
+        elif bias.shape[:2] == (1, 1):
+            bias = repeat(bias, '1 h ... -> b h ...', b=batch)
+            bias = repeat(bias, 'b 1 ... -> b h ...', h=nheads)
         assert bias.shape[:2] == (
             batch, nheads
-        ), 'First 2 dimensions of bias must be broadcastible to (batch, nheads)'
+        ), f'First 2 dimensions of bias must be broadcastible to (batch, nheads) = ({batch, nheads}). Bias has shape: {bias.shape}'
     assert bias is not None  # type checking
     bias_strides = (bias.stride(0), bias.stride(1),
                     bias.stride(2)) if has_bias else (0, 0, 0)

--- a/bert/src/flash_attn_triton.py
+++ b/bert/src/flash_attn_triton.py
@@ -802,7 +802,7 @@ def _flash_attn_forward(q, k, v, bias=None, causal=False, softmax_scale=None):
             bias = repeat(bias, 'b 1 ... -> b h ...', h=nheads)
         assert bias.shape[:2] == (
             batch, nheads
-        ), 'First 2 dimensions of bias must be broadcastible to (batch, nheads)'
+        ), f'First 2 dimensions of bias must be broadcastible to (batch, nheads). Bias has shape: {bias.shape}'
     assert bias is not None  # for type checking
     bias_strides = (bias.stride(0), bias.stride(1),
                     bias.stride(2)) if has_bias else (0, 0, 0)

--- a/llm/src/flash_attention.py
+++ b/llm/src/flash_attention.py
@@ -1,0 +1,121 @@
+# Copyright 2022 MosaicML Examples authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Triton implementation of Flash Attention Layer
+
+Modified from:
+https://raw.githubusercontent.com/HazyResearch/flash-attention/main/flash_attn/flash_attention.py
+"""
+
+import math
+import torch
+import torch.nn as nn
+from torch import Tensor
+from einops import rearrange
+from typing import List, Optional, Tuple, Union
+
+try:
+    from src.flash_attn_triton import flash_attn_qkvpacked_func, flash_attn_func
+except ImportError as e:
+    raise e
+
+
+class FlashAttention(nn.Module):
+    """Implement the scaled dot product attention with softmax.
+    Arguments
+    ---------
+        softmax_scale: The temperature to use for the softmax attention.
+                      (default: 1/sqrt(d_keys) where d_keys is computed at
+                      runtime)
+        attention_dropout: The dropout rate to apply to the attention
+                           (default: 0.0)
+    """
+    def __init__(self, num_heads, softmax_scale=None, attention_dropout=0.0, device=None, dtype=None):
+        super().__init__()
+        self.num_heads = num_heads
+        self.softmax_scale = softmax_scale
+        assert attention_dropout == 0
+        self.dropout_p = attention_dropout
+
+    def forward(
+        self,
+        qkv,
+        key_padding_mask: Optional[Tensor] = None,
+        attn_mask: Optional[Tensor] = None,
+        is_causal : bool = False,
+        need_weights: bool = False,
+        average_attn_weights: bool = True) -> Tuple[Tensor, Optional[Tensor]]:
+        """Implements the multihead softmax attention.
+        Arguments
+        ---------
+            qkv: The tensor containing the query, key, and value. (B, S, 3, H, D) if key_padding_mask is None
+                if unpadded: (nnz, 3, h, d)
+            key_padding_mask: If specified, a mask of shape :math:`(N, S)` indicating which elements within ``key``
+                to ignore for the purpose of attention (i.e. treat as "padding"). For unbatched `query`, shape should be :math:`(S)`.
+                Binary and byte masks are supported.
+                For a binary mask, a ``True`` value indicates that the corresponding ``key`` value will be ignored for
+                the purpose of attention. For a float mask, it will be directly added to the corresponding ``key`` value.
+            attn_mask: If specified, a 2D or 3D mask preventing attention to certain positions. Must be of shape
+                :math:`(L, S)` or :math:`(N\cdot\text{num\_heads}, L, S)`, where :math:`N` is the batch size,
+                :math:`L` is the target sequence length, and :math:`S` is the source sequence length. A 2D mask will be
+                broadcasted across the batch while a 3D mask allows for a different mask for each entry in the batch.
+                Binary, byte, and float masks are supported. For a binary mask, a ``True`` value indicates that the
+                corresponding position is not allowed to attend. For a byte mask, a non-zero value indicates that the
+                corresponding position is not allowed to attend. For a float mask, the mask values will be added to
+                the attention weight.
+            is_causal: If specified, applies a causal mask as attention mask. Mutually exclusive with providing attn_mask.
+                Default: ``False``.
+            need_weights: If specified, returns ``attn_output_weights`` in addition to ``attn_outputs``.
+                Default: ``True``.
+            average_attn_weights: If true, indicates that the returned ``attn_weights`` should be averaged across
+                heads. Otherwise, ``attn_weights`` are provided separately per head. Note that this flag only has an
+                effect when ``need_weights=True``. Default: ``True`` (i.e. average weights across heads)
+        """
+        assert not need_weights and not average_attn_weights
+        assert qkv.dtype in [torch.float16, torch.bfloat16]
+        assert qkv.is_cuda
+
+        if key_padding_mask is not None and key_padding_mask.bool().logical_not().any():
+            raise NotImplementedError(f'assumes key_padding_mask is taken care of by attn_mask')
+        qkv = rearrange(qkv,
+                        'b s (t h d) -> b s t h d',
+                        t=3,
+                        h=self.num_heads)
+
+        attn_output = flash_attn_qkvpacked_func(qkv, attn_mask, is_causal, None)
+        output = rearrange(attn_output, 'b s h d -> b s (h d)')
+        return output, None
+
+
+class FlashMHA(nn.Module):
+
+    def __init__(self, embed_dim, num_heads, bias=True, batch_first=True, attention_dropout=0.0,
+                 causal=False, device=None, dtype=None, **kwargs) -> None:
+        assert batch_first
+        factory_kwargs = {'device': device, 'dtype': dtype}
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.causal = causal
+
+        self.num_heads = num_heads
+        assert self.embed_dim % num_heads == 0, "self.kdim must be divisible by num_heads"
+        self.head_dim = self.embed_dim // num_heads
+        assert self.head_dim % 8 == 0 and self.head_dim <= 128, "Only support head_dim <= 128 and divisible by 8"
+
+        self.Wqkv = nn.Linear(embed_dim, 3 * embed_dim, bias=bias, **factory_kwargs)
+        self.inner_attn = FlashAttention(num_heads=num_heads, attention_dropout=attention_dropout, **factory_kwargs)
+        self.out_proj = nn.Linear(embed_dim, embed_dim, bias=bias, **factory_kwargs)
+
+    def forward(self, x, key_padding_mask=None, attn_mask=None, need_weights=False):
+        """x: (batch, seqlen, hidden_dim) (where hidden_dim = num heads * head dim)
+        key_padding_mask: bool tensor of shape (batch, seqlen)
+        """
+        qkv = self.Wqkv(x)
+        context, attn_weights = self.inner_attn(
+            qkv,
+            key_padding_mask=key_padding_mask,
+            attn_mask=attn_mask,
+            is_causal=self.causal,
+            need_weights=need_weights,
+            average_attn_weights=False)
+        return self.out_proj(context), attn_weights

--- a/llm/src/flash_attention.py
+++ b/llm/src/flash_attention.py
@@ -82,7 +82,7 @@ class FlashAttention(nn.Module):
                         t=3,
                         h=self.num_heads)
 
-        attn_output = flash_attn_qkvpacked_func(qkv, attn_mask, is_causal, None)
+        attn_output = flash_attn_qkvpacked_func(qkv, attn_mask, is_causal, self.softmax_scale)
         output = rearrange(attn_output, 'b s h d -> b s (h d)')
         return output, None
 
@@ -103,7 +103,7 @@ class FlashMHA(nn.Module):
         assert self.head_dim % 8 == 0 and self.head_dim <= 128, "Only support head_dim <= 128 and divisible by 8"
 
         self.Wqkv = nn.Linear(embed_dim, 3 * embed_dim, bias=bias, **factory_kwargs)
-        self.inner_attn = FlashAttention(num_heads=num_heads, attention_dropout=attention_dropout, **factory_kwargs)
+        self.inner_attn = FlashAttention(num_heads=num_heads, softmax_scale=None, attention_dropout=attention_dropout, **factory_kwargs)
         self.out_proj = nn.Linear(embed_dim, embed_dim, bias=bias, **factory_kwargs)
 
     def forward(self, x, key_padding_mask=None, attn_mask=None, need_weights=False):

--- a/llm/src/flash_attention.py
+++ b/llm/src/flash_attention.py
@@ -27,15 +27,11 @@ class FlashAttention(nn.Module):
         softmax_scale: The temperature to use for the softmax attention.
                       (default: 1/sqrt(d_keys) where d_keys is computed at
                       runtime)
-        attention_dropout: The dropout rate to apply to the attention
-                           (default: 0.0)
     """
-    def __init__(self, num_heads, softmax_scale=None, attention_dropout=0.0, device=None, dtype=None):
+    def __init__(self, num_heads, softmax_scale=None, device=None, dtype=None):
         super().__init__()
         self.num_heads = num_heads
         self.softmax_scale = softmax_scale
-        assert attention_dropout == 0
-        self.dropout_p = attention_dropout
 
     def forward(
         self,
@@ -89,7 +85,7 @@ class FlashAttention(nn.Module):
 
 class FlashMHA(nn.Module):
 
-    def __init__(self, embed_dim, num_heads, bias=True, batch_first=True, attention_dropout=0.0,
+    def __init__(self, embed_dim, num_heads, bias=True, batch_first=True,
                  causal=False, device=None, dtype=None, **kwargs) -> None:
         assert batch_first
         factory_kwargs = {'device': device, 'dtype': dtype}
@@ -103,7 +99,7 @@ class FlashMHA(nn.Module):
         assert self.head_dim % 8 == 0 and self.head_dim <= 128, "Only support head_dim <= 128 and divisible by 8"
 
         self.Wqkv = nn.Linear(embed_dim, 3 * embed_dim, bias=bias, **factory_kwargs)
-        self.inner_attn = FlashAttention(num_heads=num_heads, softmax_scale=None, attention_dropout=attention_dropout, **factory_kwargs)
+        self.inner_attn = FlashAttention(num_heads=num_heads, softmax_scale=None, **factory_kwargs)
         self.out_proj = nn.Linear(embed_dim, embed_dim, bias=bias, **factory_kwargs)
 
     def forward(self, x, key_padding_mask=None, attn_mask=None, need_weights=False):

--- a/llm/src/flash_attn_triton.py
+++ b/llm/src/flash_attn_triton.py
@@ -800,6 +800,9 @@ def _flash_attn_forward(q, k, v, bias=None, causal=False, softmax_scale=None):
             bias = repeat(bias, '1 h ... -> b h ...', b=batch)
         elif bias.shape[:2] == (batch, 1):
             bias = repeat(bias, 'b 1 ... -> b h ...', h=nheads)
+        elif bias.shape[:2] == (1, 1):
+            bias = repeat(bias, '1 h ... -> b h ...', b=batch)
+            bias = repeat(bias, 'b 1 ... -> b h ...', h=nheads)
         assert bias.shape[:2] == (
             batch, nheads
         ), f'First 2 dimensions of bias must be broadcastible to (batch, nheads) = ({batch, nheads}). Bias has shape: {bias.shape}'

--- a/llm/src/flash_attn_triton.py
+++ b/llm/src/flash_attn_triton.py
@@ -802,7 +802,7 @@ def _flash_attn_forward(q, k, v, bias=None, causal=False, softmax_scale=None):
             bias = repeat(bias, 'b 1 ... -> b h ...', h=nheads)
         assert bias.shape[:2] == (
             batch, nheads
-        ), f'First 2 dimensions of bias must be broadcastible to (batch, nheads). Bias has shape: {bias.shape}'
+        ), f'First 2 dimensions of bias must be broadcastible to (batch, nheads) = ({batch, nheads}). Bias has shape: {bias.shape}'
     assert bias is not None  # for type checking
     bias_strides = (bias.stride(0), bias.stride(1),
                     bias.stride(2)) if has_bias else (0, 0, 0)

--- a/llm/src/flash_attn_triton.py
+++ b/llm/src/flash_attn_triton.py
@@ -931,9 +931,12 @@ def _flash_attn_backward(do,
             bias = repeat(bias, '1 h ... -> b h ...', b=batch)
         elif bias.shape[:2] == (batch, 1):
             bias = repeat(bias, 'b 1 ... -> b h ...', h=nheads)
+        elif bias.shape[:2] == (1, 1):
+            bias = repeat(bias, '1 h ... -> b h ...', b=batch)
+            bias = repeat(bias, 'b 1 ... -> b h ...', h=nheads)
         assert bias.shape[:2] == (
             batch, nheads
-        ), 'First 2 dimensions of bias must be broadcastible to (batch, nheads)'
+        ), f'First 2 dimensions of bias must be broadcastible to (batch, nheads) = ({batch, nheads}). Bias has shape: {bias.shape}'
     assert bias is not None  # type checking
     bias_strides = (bias.stride(0), bias.stride(1),
                     bias.stride(2)) if has_bias else (0, 0, 0)

--- a/llm/src/flash_attn_triton.py
+++ b/llm/src/flash_attn_triton.py
@@ -802,7 +802,7 @@ def _flash_attn_forward(q, k, v, bias=None, causal=False, softmax_scale=None):
             bias = repeat(bias, 'b 1 ... -> b h ...', h=nheads)
         assert bias.shape[:2] == (
             batch, nheads
-        ), 'First 2 dimensions of bias must be broadcastible to (batch, nheads)'
+        ), f'First 2 dimensions of bias must be broadcastible to (batch, nheads). Bias has shape: {bias.shape}'
     assert bias is not None  # for type checking
     bias_strides = (bias.stride(0), bias.stride(1),
                     bias.stride(2)) if has_bias else (0, 0, 0)

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -17,8 +17,6 @@ from composer.metrics.nlp import LanguageCrossEntropy, Perplexity
 from composer.models.base import ComposerModel
 from omegaconf import DictConfig
 
-from einops import rearrange
-
 
 class TorchCausalAttention(nn.Module):
 

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -147,8 +147,8 @@ class TritonFlashCausalAttention(nn.Module):
         self.attn_bias_initialized = True
 
     def forward(self, x, key_padding_mask):
-        if key_padding_mask.count_nonzero():
-            raise NotImplementedError(f'TritonFlashCausalAttention does not ignore any input tokens')
+        if key_padding_mask.count_nonzero() != key_padding_mask.numel():
+            raise NotImplementedError(f'TritonFlashCausalAttention does not ignore input tokens')
         if not self.attn_bias_initialized:
             self._fill_attn_bias()
 

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -135,10 +135,15 @@ class TritonFlashCausalAttention(nn.Module):
             # bias: optional, shape broadcastible to (batch, nheads, seqlen, seqlen).
             #     For example, ALiBi mask for causal would have shape (1, nheads, 1, seqlen).
             #     ALiBi mask for non-causal would have shape (1, nheads, seqlen, seqlen)
-            attn_bias = -torch.arange(self.seq_len).view(1, self.seq_len)  # should be of shape = (1, nheads, 1, seqlen)
-            attn_bias = attn_bias * (1 / torch.arange(self.n_heads).view(self.n_heads, 1))  # TODO figure out if this is correct...
-            attn_bias = attn_bias.view(1, self.n_heads, 1, self.seq_len)
-            self.attn_bias.fill_(attn_bias)
+            # attn_bias = -torch.arange(self.seq_len).view(1, self.seq_len)  # should be of shape = (1, nheads, 1, seqlen)
+            # attn_bias = attn_bias * (1 / torch.arange(self.n_heads).view(self.n_heads, 1))  # TODO figure out if this is correct...
+            # attn_bias = attn_bias.view(1, self.n_heads, 1, self.seq_len)
+            # self.attn_bias.fill_(attn_bias)
+            torch.full(size=self.attn_bias.shape,
+                   fill_value=1,
+                   out=self.attn_bias)
+            self.attn_bias *= -torch.arange(self.seq_len).view(1, 1, 1, self.seq_len)
+            self.attn_bias *= (1 / torch.arange(self.n_heads).view(1, self.n_heads, 1, 1))  # TODO figure out if this is correct...
             
         self.attn_bias_initialized = True
 

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -143,7 +143,7 @@ class TritonFlashCausalAttention(nn.Module):
         self.attn_bias_initialized = True
 
     def forward(self, x, key_padding_mask):
-        if self.attn_bias and not self.attn_bias_initialized:
+        if not self.attn_bias_initialized and self.ablibi:
             self._fill_alibi_attn_mask()
 
         qkv = self.Wqkv(x)

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -136,7 +136,7 @@ class TritonFlashCausalAttention(nn.Module):
             #     For example, ALiBi mask for causal would have shape (1, nheads, 1, seqlen).
             #     ALiBi mask for non-causal would have shape (1, nheads, seqlen, seqlen)
             attn_bias = -torch.arange(self.seq_len).view(1, self.seq_len)  # should be of shape = (1, nheads, 1, seqlen)
-            attn_bias *= (1 / torch.arange(self.n_heads).view(self.n_heads, 1))
+            attn_bias *= (1 / torch.arange(self.n_heads).view(self.n_heads, 1))  # TODO figure out if this is correct...
             attn_bias = attn_bias.view(1, self.n_heads, 1, self.seq_len)
             self.attn_bias.fill_(attn_bias)
             

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -148,6 +148,10 @@ class TritonFlashCausalAttention(nn.Module):
             self.attn_bias += 1
             self.attn_bias *= alibi_bias
 
+            assert not self.attn_bias.isnan().any(), f'attn bias has NaNs'
+            print(self.attn_bias)
+            exit()
+
         self.attn_bias_initialized = True
 
     def forward(self, x, key_padding_mask):

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -310,7 +310,6 @@ class MosaicGPT(nn.Module):
         ), f'Cannot forward input with seq_len={S}, this model only supports seq_len<={self.cfg.max_seq_len}'
 
         tok_emb = self.transformer.wte(input_ids)  # type: ignore
-
         if self.alibi:
             x = tok_emb
         else:

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -147,6 +147,8 @@ class TritonFlashCausalAttention(nn.Module):
         self.attn_bias_initialized = True
 
     def forward(self, x, key_padding_mask):
+        if key_padding_mask.count_nonzero():
+            raise NotImplementedError(f'TritonFlashCausalAttention does not ignore any input tokens')
         if not self.attn_bias_initialized:
             self._fill_attn_bias()
 

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -159,8 +159,9 @@ class TritonFlashCausalAttention(nn.Module):
         # key_padding_mask must be handeled by setting mask to -inf
         _n_heads = n_heads if alibi else 1
 
-        attn_mask = torch.full(size=(batch_size, _n_heads, seq_len, seq_len), fill_value=float('-inf'), device=device, dtype=dtype)
+        attn_mask = torch.full(size=(1, 1, seq_len, seq_len), fill_value=float('-inf'), device=device, dtype=dtype)
         torch.triu(input=attn_mask, diagonal=1, out=attn_mask)
+        attn_mask = attn_mask.expand(batch_size, _n_heads, seq_len, seq_len)
 
         attn_mask.masked_fill_(~key_padding_mask.reshape(batch_size, 1, 1, seq_len), float('-inf'))
         attn_mask.masked_fill_(~key_padding_mask.reshape(batch_size, 1, seq_len, 1), float('-inf'))

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -123,7 +123,9 @@ class TritonFlashCausalAttention(nn.Module):
                 'attn_bias',
                 torch.empty((1, self.n_heads, self.seq_len, self.seq_len), device=device))
         else:
-            self.attn_bias = None
+            self.register_buffer(
+                'attn_bias',
+                torch.empty((1, 1, self.seq_len, self.seq_len), device=device))
         self.attn_bias_initialized = False
 
         self.out_proj = nn.Linear(cfg.d_model, cfg.d_model, bias=True, device=device)
@@ -149,11 +151,10 @@ class TritonFlashCausalAttention(nn.Module):
 
             assert not self.attn_bias.isnan().any(), f"Attn bias shouldn't have NaNs"
         else:
-            # torch.full(size=self.attn_bias.shape,
-            #             fill_value=float('-inf'),
-            #             out=self.attn_bias)
-            # torch.triu(input=self.attn_bias, diagonal=1, out=self.attn_bias)
-            pass  # self.attn_bias = None
+            torch.full(size=self.attn_bias.shape,
+                        fill_value=float('-inf'),
+                        out=self.attn_bias)
+            torch.triu(input=self.attn_bias, diagonal=1, out=self.attn_bias)
 
         self.attn_bias_initialized = True
 

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -136,7 +136,7 @@ class TritonFlashCausalAttention(nn.Module):
             #     For example, ALiBi mask for causal would have shape (1, nheads, 1, seqlen).
             #     ALiBi mask for non-causal would have shape (1, nheads, seqlen, seqlen)
             attn_bias = -torch.arange(self.seq_len).view(1, self.seq_len)  # should be of shape = (1, nheads, 1, seqlen)
-            attn_bias *= (1 / torch.arange(self.n_heads).view(self.n_heads, 1))  # TODO figure out if this is correct...
+            attn_bias = attn_bias * (1 / torch.arange(self.n_heads).view(self.n_heads, 1))  # TODO figure out if this is correct...
             attn_bias = attn_bias.view(1, self.n_heads, 1, self.seq_len)
             self.attn_bias.fill_(attn_bias)
             

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -132,7 +132,7 @@ class TritonFlashCausalAttention(nn.Module):
         self.out_proj._is_residual = True
 
     def _fill_attn_bias(self, bias_max: int = 8):
-        self.attn_bias.zeros_()
+        self.attn_bias.zero_()
 
         if self.alibi:
             dtype, device = self.attn_bias.dtype, self.attn_bias.device

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -130,7 +130,7 @@ class TritonFlashCausalAttention(nn.Module):
         self.out_proj._is_residual = True
 
     def _fill_alibi_attn_mask(self):
-        assert isinstance(self.bias, torch.Tensor)  # for type checking
+        assert isinstance(self.attn_bias, torch.Tensor)  # for type checking
         if self.alibi:
             # bias: optional, shape broadcastible to (batch, nheads, seqlen, seqlen).
             #     For example, ALiBi mask for causal would have shape (1, nheads, 1, seqlen).

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -166,7 +166,7 @@ class TritonFlashCausalAttention(nn.Module):
         bias[key_padding_mask == 0] = float('-inf')
         bias = bias.view(-1, 1, 1, self.seq_len)
         if self.alibi:
-            bais *= self.attn_bias
+            bias *= self.attn_bias
         attention = self.mhsa(
             qkv,
             bias,

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -236,13 +236,13 @@ class MosaicGPT(nn.Module):
         
         self.transformer = nn.ModuleDict({"wte": nn.Embedding(cfg.vocab_size, cfg.d_model, device=cfg.device)})
         if not cfg.get('alibi', False):
-            self.transformer.append({'wpe': nn.Embedding(cfg.max_seq_len, cfg.d_model, device=cfg.device)})
-        self.transformer.append({'emb_drop': nn.Dropout(cfg.emb_pdrop)})
-        self.transformer.append({'blocks': nn.ModuleList([
+            self.transformer.update({'wpe': nn.Embedding(cfg.max_seq_len, cfg.d_model, device=cfg.device)})
+        self.transformer.update({'emb_drop': nn.Dropout(cfg.emb_pdrop)})
+        self.transformer.update({'blocks': nn.ModuleList([
                     GPTBlock(cfg, device=cfg.device)
                     for _ in range(cfg.n_layers)
                 ])})
-        self.transformer.append({'ln_f': nn.LayerNorm(cfg.d_model, device=cfg.device)})
+        self.transformer.update({'ln_f': nn.LayerNorm(cfg.d_model, device=cfg.device)})
 
         if cfg.device != 'meta':
             self.apply(self.param_init_fn)

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -136,7 +136,9 @@ class TritonFlashCausalAttention(nn.Module):
 
         if self.alibi:
             dtype, device = self.attn_bias.dtype, self.attn_bias.device
+            
             alibi_bias = torch.arange(1 - self.seq_len, 1, dtype=dtype, device=device).view(1, 1, 1, self.seq_len)
+            
             m = torch.arange(1, self.n_heads + 1, dtype=dtype, device=device) * bias_max / self.n_heads
             alibi_bias = alibi_bias * (1. / (2 ** m.view(1, self.n_heads, 1, 1)))
 

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -130,7 +130,6 @@ class TritonFlashCausalAttention(nn.Module):
         self.out_proj._is_residual = True
 
     def _fill_attn_bias(self, bias_max: int = 8):
-        assert isinstance(self.attn_bias, torch.Tensor)  # for type checking
         if self.alibi:
             torch.full(size=self.attn_bias.shape,
                         fill_value=float('inf'),
@@ -150,10 +149,11 @@ class TritonFlashCausalAttention(nn.Module):
 
             assert not self.attn_bias.isnan().any(), f"Attn bias shouldn't have NaNs"
         else:
-            torch.full(size=self.attn_bias.shape,
-                        fill_value=float('-inf'),
-                        out=self.attn_bias)
-            torch.triu(input=self.attn_bias, diagonal=1, out=self.attn_bias)
+            # torch.full(size=self.attn_bias.shape,
+            #             fill_value=float('-inf'),
+            #             out=self.attn_bias)
+            # torch.triu(input=self.attn_bias, diagonal=1, out=self.attn_bias)
+            pass  # self.attn_bias = None
 
         self.attn_bias_initialized = True
 

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -280,7 +280,6 @@ class MosaicGPT(nn.Module):
                 # Note: if key_padding_mask is triggered, the needed expansion is already done.
                 attn_mask = attn_mask.expand(x.size(0), *self.attn_mask.shape).reshape(-1, *self.attn_mask.shape[-2:])
 
-
             return attn_mask
             
         return self.attn_mask

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -265,7 +265,6 @@ class MosaicGPT(nn.Module):
         # define attn mask
         self._attn_mask_initialized = False
         mask_shape = self.causal_attn_cls.mask_shape(cfg.n_heads, cfg.max_seq_len, self.alibi)
-
         if mask_shape:
             self.register_buffer('attn_mask', torch.empty(mask_shape, device=cfg.device))
         else:
@@ -276,12 +275,23 @@ class MosaicGPT(nn.Module):
             if key_padding_mask is not None and key_padding_mask.bool().logical_not().any():
                 # run if key_padding_mask signifies any tokens are invalid
                 return self.causal_attn_cls.attn_mask(
-                    key_padding_mask, x.size(0), self.cfg.n_heads, x.size(1), alibi=self.alibi, alibi_bias_max=self.alibi_bias_max, device=x.device, dtype=x.dtype)
+                    key_padding_mask,
+                    x.size(0),
+                    self.cfg.n_heads,
+                    x.size(1),
+                    alibi=self.alibi,
+                    alibi_bias_max=self.alibi_bias_max,
+                    device=x.device,
+                    dtype=x.dtype)
 
         if self._attn_mask_initialized:
             return self.attn_mask
         self.causal_attn_cls.attn_mask_(
-            self.attn_mask, self.cfg.n_heads, self.cfg.max_seq_len, alibi=self.alibi, alibi_bias_max=self.alibi_bias_max)
+            self.attn_mask,
+            self.cfg.n_heads,
+            self.cfg.max_seq_len,
+            alibi=self.alibi,
+            alibi_bias_max=self.alibi_bias_max)
         self._attn_mask_initialized = True
         return self.attn_mask
 

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -137,16 +137,15 @@ class TritonFlashCausalAttention(nn.Module):
         torch.triu(input=self.attn_bias, diagonal=1, out=self.attn_bias)
         
         if self.alibi:
-            self.attn_bias += 1
-
             dtype, device = self.attn_bias.dtype, self.attn_bias.device
             alibi_bias = torch.arange(self.seq_len, dtype=dtype, device=device).view(1, 1, 1, self.seq_len)
             alibi_bias = alibi_bias - torch.arange(self.seq_len, dtype=dtype, device=device).view(1, 1, self.seq_len, 1)
             alibi_bias.abs_().mul_(-1.)
             # TODO figure out if this is correct...
             m = torch.arange(1, self.n_heads + 1, dtype=dtype, device=device) * bias_max / self.n_heads
-            alibi_bias *= (1. / (2 ** m.view(1, self.n_heads, 1, 1)))
+            alibi_bias = alibi_bias * (1. / (2 ** m.view(1, self.n_heads, 1, 1)))
 
+            self.attn_bias += 1
             self.attn_bias *= alibi_bias
 
         self.attn_bias_initialized = True

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -147,6 +147,8 @@ class TritonFlashCausalAttention(nn.Module):
         self.attn_bias_initialized = True
 
     def forward(self, x, key_padding_mask):
+        if key_padding_mask.bool().logical_not().any():
+            raise NotImplementedError(f'triton attn does not support key_padding_mask')
         if not self.attn_bias_initialized:
             self._fill_attn_bias()
 

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -135,13 +135,14 @@ class TritonFlashCausalAttention(nn.Module):
                    fill_value=float('-inf'),
                    out=self.attn_bias)
         torch.triu(input=self.attn_bias, diagonal=1, out=self.attn_bias)
-        self.attn_bias += 1
-
+        
         if self.alibi:
+            self.attn_bias += 1
+
             dtype, device = self.attn_bias.dtype, self.attn_bias.device
             alibi_bias = torch.arange(self.seq_len, dtype=dtype, device=device).view(1, 1, 1, self.seq_len)
-            alibi_bias -= torch.arange(self.seq_len, dtype=dtype, device=device).view(1, 1, self.seq_len, 1)
-            alibi_bias.abs_().mul_(-1.).tril_()
+            alibi_bias = alibi_bias - torch.arange(self.seq_len, dtype=dtype, device=device).view(1, 1, self.seq_len, 1)
+            alibi_bias.abs_().mul_(-1.)
             # TODO figure out if this is correct...
             m = torch.arange(1, self.n_heads + 1, dtype=dtype, device=device) * bias_max / self.n_heads
             alibi_bias *= (1. / (2 ** m.view(1, self.n_heads, 1, 1)))

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -142,8 +142,8 @@ class TritonFlashCausalAttention(nn.Module):
             torch.full(size=self.attn_bias.shape,
                    fill_value=1,
                    out=self.attn_bias)
-            self.attn_bias *= -torch.arange(self.seq_len).view(1, 1, 1, self.seq_len)
-            self.attn_bias *= (1 / torch.arange(self.n_heads).view(1, self.n_heads, 1, 1))  # TODO figure out if this is correct...
+            self.attn_bias *= -torch.arange(self.seq_len).to(dtype=self.attn_bias.dtype, device=self.attn_bias.device).view(1, 1, 1, self.seq_len)
+            self.attn_bias *= (1 / torch.arange(self.n_heads).to(dtype=self.attn_bias.dtype, device=self.attn_bias.device).view(1, self.n_heads, 1, 1))  # TODO figure out if this is correct...
             
         self.attn_bias_initialized = True
 

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -166,7 +166,7 @@ class TritonFlashCausalAttention(nn.Module):
         bias[key_padding_mask == 0] = float('-inf')
         bias = bias.view(-1, 1, 1, self.seq_len)
         if self.alibi:
-            bias *= self.attn_bias
+            bias = bias * self.attn_bias
         attention = self.mhsa(
             qkv,
             bias,

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -143,7 +143,7 @@ class TritonFlashCausalAttention(nn.Module):
                    fill_value=1,
                    out=self.attn_bias)
             self.attn_bias *= -torch.arange(self.seq_len).to(dtype=self.attn_bias.dtype, device=self.attn_bias.device).view(1, 1, 1, self.seq_len)
-            self.attn_bias *= (1 / torch.arange(self.n_heads).to(dtype=self.attn_bias.dtype, device=self.attn_bias.device).view(1, self.n_heads, 1, 1))  # TODO figure out if this is correct...
+            self.attn_bias *= (1. / torch.arange(self.n_heads).to(dtype=self.attn_bias.dtype, device=self.attn_bias.device).view(1, self.n_heads, 1, 1))  # TODO figure out if this is correct...
             
         self.attn_bias_initialized = True
 

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -137,22 +137,20 @@ class TritonFlashCausalAttention(nn.Module):
         torch.triu(input=self.attn_bias, diagonal=1, out=self.attn_bias)
         
         if self.alibi:
+            # TODO I think this is correct, but is it correct????
             dtype, device = self.attn_bias.dtype, self.attn_bias.device
             alibi_bias = torch.arange(self.seq_len, dtype=dtype, device=device).view(1, 1, 1, self.seq_len)
             alibi_bias = alibi_bias - torch.arange(self.seq_len, dtype=dtype, device=device).view(1, 1, self.seq_len, 1)
             alibi_bias.abs_().mul_(-1.)  # negative distance / convert to -inf
-            # TODO figure out if this is correct...
             m = torch.arange(1, self.n_heads + 1, dtype=dtype, device=device) * bias_max / self.n_heads
             alibi_bias = alibi_bias * (1. / (2 ** m.view(1, self.n_heads, 1, 1)))
 
             self.attn_bias.add_(1)
             self.attn_bias.mul_(alibi_bias)
 
-            assert not self.attn_bias.isnan().any(), f'attn bias has NaNs'
-            print(self.attn_bias)
-            exit()
+            assert not self.attn_bias.isnan().any(), f"Attn bias shouldn't have NaNs"
         else:
-            self.attn_bias.mul_(-1.)  # convert to -inf
+            self.attn_bias.mul_(-1.)  # convert bias to -inf
 
         self.attn_bias_initialized = True
 

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -213,7 +213,7 @@ class MosaicGPT(nn.Module):
         if key_padding_mask is not None and key_padding_mask.bool().logical_not().any():
             # Triton kernel does not handel key_padding_mask
             # key_padding_mask must be handeled by setting mask to -inf
-            dtype, device = x.dtype, x.device
+            device, dtype = x.device, x.dtype
 
             B = x.size(0)
             seq_len = x.size(1)
@@ -227,7 +227,7 @@ class MosaicGPT(nn.Module):
             attn_mask += m
 
             if self.alibi:
-                attn_mask.add_(self._alibi(_n_heads, seq_len, full=True, alibi_bias_max=self.alibi_bias_max, device=dtype, dtype=device))
+                attn_mask.add_(self._alibi(_n_heads, seq_len, full=True, alibi_bias_max=self.alibi_bias_max, device=device, dtype=dtype))
 
             return attn_mask
 
@@ -238,10 +238,10 @@ class MosaicGPT(nn.Module):
         self.attn_mask.zero_()
 
         if self.alibi:
-            dtype, device = self.attn_mask.dtype, self.attn_mask.device
+            device, dtype = self.attn_mask.device, self.attn_mask.dtype
 
             if self.alibi:
-                self.attn_mask.add_(self._alibi(self.cfg.n_heads, self.cfg.max_seq_len, full=False, alibi_bias_max=self.alibi_bias_max, device=dtype, dtype=device))
+                self.attn_mask.add_(self._alibi(self.cfg.n_heads, self.cfg.max_seq_len, full=False, alibi_bias_max=self.alibi_bias_max, device=device, dtype=dtype))
         
         self._attn_mask_initialized = True
         

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -147,8 +147,6 @@ class TritonFlashCausalAttention(nn.Module):
         self.attn_bias_initialized = True
 
     def forward(self, x, key_padding_mask):
-        if key_padding_mask.count_nonzero() != key_padding_mask.numel():
-            raise NotImplementedError(f'TritonFlashCausalAttention does not ignore input tokens')
         if not self.attn_bias_initialized:
             self._fill_attn_bias()
 

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -196,11 +196,11 @@ class MosaicGPT(nn.Module):
         else:
             self.attn_mask = None
 
-    def _alibi(self, dtype, device, full=False):
-        alibi_bias = torch.arange(1 - self.cfg.max_seq_len, 1, dtype=dtype, device=device).view(1, 1, 1, self.cfg.max_seq_len)
+    def _alibi(self, dtype, device, seq_len, full=False):
+        alibi_bias = torch.arange(1 - seq_len, 1, dtype=dtype, device=device).view(1, 1, 1, seq_len)
         if full:
             # if full, the generated alibi mask is 1 x Heads x SeqLen x SeqLen else mask is 1 x Heads x 1 x SeqLen (which is braodcasted up)
-            alibi_bias = alibi_bias + torch.arange(1 - self.cfg.max_seq_len, 1, dtype=dtype, device=device).view(1, 1, self.cfg.max_seq_len, 1)
+            alibi_bias = alibi_bias + torch.arange(1 - seq_len, 1, dtype=dtype, device=device).view(1, 1, seq_len, 1)
 
         m = torch.arange(1, self.cfg.n_heads + 1, dtype=dtype, device=device) * self.alibi_bias_max / self.cfg.n_heads
         alibi_bias = alibi_bias * (1. / (2 ** m.view(1, self.cfg.n_heads, 1, 1)))
@@ -216,18 +216,18 @@ class MosaicGPT(nn.Module):
             dtype, device = x.dtype, x.device
 
             B = x.size(0)
-            S = self.cfg.max_seq_len
+            seq_len = x.size(1)
             n_heads = self.cfg.n_heads if self.alibi else 1
 
-            attn_mask = torch.zeros((B, n_heads, S, S), dtype=dtype, device=device)
+            attn_mask = torch.zeros((B, n_heads, seq_len, seq_len), dtype=dtype, device=device)
             
-            m = (~key_padding_mask).reshape(B, 1, 1, S)
-            m = m * (~key_padding_mask).reshape(B, 1, S, 1)
+            m = (~key_padding_mask).reshape(B, 1, 1, seq_len)
+            m = m * (~key_padding_mask).reshape(B, 1, seq_len, 1)
             m[m == 1] = float('-inf')
             attn_mask += m
 
             if self.alibi:
-                attn_mask.add_(self._alibi(dtype, device, full=True))
+                attn_mask.add_(self._alibi(dtype, device, seq_len, full=True))
 
             return attn_mask
 
@@ -241,7 +241,7 @@ class MosaicGPT(nn.Module):
             dtype, device = self.attn_mask.dtype, self.attn_mask.device
 
             if self.alibi:
-                self.attn_mask.add_(self._alibi(dtype, device, full=False))
+                self.attn_mask.add_(self._alibi(dtype, device, self.cfg.max_seq_len, full=False))
         
         self._attn_mask_initialized = True
         

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -131,12 +131,12 @@ class TritonFlashCausalAttention(nn.Module):
 
     def _fill_attn_bias(self, bias_max: int = 8):
         assert isinstance(self.attn_bias, torch.Tensor)  # for type checking
-        torch.full(size=self.attn_bias.shape,
-                   fill_value=float('inf'),
-                   out=self.attn_bias)
-        torch.triu(input=self.attn_bias, diagonal=1, out=self.attn_bias)
-        
         if self.alibi:
+            torch.full(size=self.attn_bias.shape,
+                        fill_value=float('inf'),
+                        out=self.attn_bias)
+            torch.triu(input=self.attn_bias, diagonal=1, out=self.attn_bias)
+
             # TODO I think this is correct, but is it correct????
             dtype, device = self.attn_bias.dtype, self.attn_bias.device
             alibi_bias = torch.arange(self.seq_len, dtype=dtype, device=device).view(1, 1, 1, self.seq_len)
@@ -150,7 +150,10 @@ class TritonFlashCausalAttention(nn.Module):
 
             assert not self.attn_bias.isnan().any(), f"Attn bias shouldn't have NaNs"
         else:
-            self.attn_bias.mul_(-1.)  # convert bias to -inf
+            torch.full(size=self.attn_bias.shape,
+                        fill_value=float('-inf'),
+                        out=self.attn_bias)
+            torch.triu(input=self.attn_bias, diagonal=1, out=self.attn_bias)
 
         self.attn_bias_initialized = True
 

--- a/llm/tests/test_hf_v_mosaic_gpt.py
+++ b/llm/tests/test_hf_v_mosaic_gpt.py
@@ -18,6 +18,7 @@ from src.model_registry import COMPOSER_MODEL_REGISTRY
         ("torch", 0.0, False, False, 1),  # requires strict=False to skip loading model.attn_mask
         ("triton", 0.0, False, False, 1),  # requires strict=False to skip loading model.attn_mask
         ("triton", 0.1, False, False, 1),  # requires strict=False to skip loading model.attn_mask
+        pytest.param("torch", 0.0, False, True, 1, marks=pytest.mark.xfail(reason="hf model is not implemented with alibi")),
         pytest.param("triton", 0.1, False, True, 1, marks=pytest.mark.xfail(reason="hf model is not implemented with alibi")),
         ("torch", 0.0, False, False, 0),  # requires strict=False to skip loading model.attn_mask, testing case where key_pad_mask is 0
         ("triton", 0.0, False, False, 0),  # requires strict=False to skip loading model.attn_mask, testing case where key_pad_mask is 0


### PR DESCRIPTION
This pr integrates the triton implementation of FlashAttn (with ALiBi) into examples/llm.
Using this variant, memory usage is the same
![Screenshot 2022-12-22 at 4 54 33 PM](https://user-images.githubusercontent.com/6439018/209249769-69e557f6-2a78-48a3-92eb-0e77aee2b9d0.png)
it runs slightly faster
![Screenshot 2022-12-22 at 4 51 15 PM](https://user-images.githubusercontent.com/6439018/209249793-3211afe6-72ca-4ceb-a63c-f5300c9320fb.png)
and with Alibi convergence is faster (and we converge to a lower final loss)
![Screenshot 2022-12-22 at 4 51 08 PM](https://user-images.githubusercontent.com/6439018/209249924-66f216a0-528d-49c9-ad8d-2622c70e05c6.png)
![Screenshot 2022-12-22 at 4 51 23 PM](https://user-images.githubusercontent.com/6439018/209249941-2d0fc4f8-678a-4162-b975-41ad44e93fe3.png)


Meta-comment: MosaicGPT is currently structured so that the Causal Attn Bias is a member of the layer. It should really be a member of the model and should then be passed to all layers in their fwd pass. FlashAttn does not take a Bias / Mask so it does not suffer the memory penalty of having multiple masks. The Torch and Triton implementations do therefore are affected by the issue. @abhi-mosaic maybe we should create an issue to track this. We could make it part of this PR, but its slightly outside the scope.

Note: I tried a symlink `bert/src/flash_attn_triton.py -> llm/src/flash_attn_triton.py` but the result was a copy pasta; I'm not sure git supports symlinks...