### PR TITLE
Disable Docker GHA job for forked repos

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   docker-build:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'mosaicml'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Currently the Docker GHA flow will run for pushes to `main` branch in the base and forked repos.  This PR gates the Docker job with a repo owner check and will only run if the owner is `mosaicml`.

The Docker GHA workflow is not compatible with forks since it requires a repo secret to run.