### PR TITLE
Refactor C4 conversion script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,11 +67,11 @@ repos:
   hooks:
   - id: pyright
     name: pyright
-    entry: pyright .
+    entry: pyright
     language: node
     types: [python]
-    pass_filenames: false
-    additional_dependencies: [pyright@1.1.281]
+    pass_filenames: true
+    additional_dependencies: ['pyright@1.1.256']
 - repo: https://github.com/PyCQA/docformatter
   rev: v1.5.0
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,7 +71,7 @@ repos:
     language: node
     types: [python]
     pass_filenames: true
-    additional_dependencies: ['pyright@1.1.256']
+    additional_dependencies: ['pyright@1.1.281']
 - repo: https://github.com/PyCQA/docformatter
   rev: v1.5.0
   hooks:

--- a/llm/README.md
+++ b/llm/README.md
@@ -50,10 +50,11 @@ Here's what you need to get started with our LLM stack:
 * Prepare a local copy of the dataset via instructions below.
 
 # Dataset preparation
-To run training, you'll need to make yourself a local copy of the pre-training dataset.
-If you only want to profile these LLMs, we recommend that you **only download and prepare the `val` split**,
-and use it for both train and eval in your script. Just change `split: train` to `split: val` in your run YAML, [e.g. here](./yamls/mosaic_gpt/125m.yaml#L32).
-Alternatively, feel free to substitute our dataloader with one of your own in [main.py](./main.py#L93)!
+To run training, you'll need to make yourself aå copy of the pre-training dataset.
+If you only want to profile these LLMs, we recommend that you **download and prepare the `train-small` and `val` splits**,
+and skip the full `train` split. You'll just need to replace `split: train` with `split: train-small` in your run YAML, [e.g. here](./yamls/mosaic_gpt/125m.yaml#L40).
+You can also accomplish this in your CLI command like so: `composer main.py ... train_loader.split=train-small`
+Alternatively, feel free to substitute our dataloader with one of your own in [main.py](./main.py#L96)!
 
 As an example, we train LLMs on the [C4: Colossal, Cleaned, Common Crawl dataset](https://huggingface.co/datasets/c4).
 We first convert the dataset from its native format (a collection of zipped JSONs)
@@ -65,15 +66,19 @@ You can read more about [the benefits of using mosaicml-streaming here](https://
 ### Converting C4 to streaming dataset `.mds` format
 To make yourself a copy of C4, use `convert_c4.py` like so:
 ```bash
-# Download the 'val' split and convert to StreamingDataset format
-# This will take 10 sec to 1 min depending on your Internet bandwidth
-# You should see a dataset folder `./my-copy-c4/val` that is ~0.5GB
-python ../scripts/convert_c4.py --out_root ./my-copy-c4 --splits val
+# Download the 'train-small', 'val' splits and convert to StreamingDataset format
+# This will take 20 sec to 1 min depending on your Internet bandwidth
+# You should see two folders `./my-copy-c4/train-small` and `./my-copy-c4/val` that are each ~0.5GB
+python ../scripts/convert_c4.py --out_root ./my-copy-c4 --splits train-small val
 
 # Download the 'train' split if you really want to train the model (not just profile)
 # This will take 1-to-many hours depending on bandwidth, # CPUs, etc.
 # The final folder `./my-copy-c4/train` will be ~800GB so make sure you have space!
 python ../scripts/convert_c4.py --out_root ./my-copy-c4 --splits train
+
+# For any of the above commands, you can also choose to compress the .mds files.
+# This is useful if your plan is to store these in object store after conversion.
+# python ../scripts/convert_c4.py ... --compression zstd
 ```
 
 ### Test the Dataloader
@@ -96,12 +101,10 @@ python ../common/text_data.py /tmp/cache-c4 s3://my-bucket/my-copy-c4
 
 Now that you've installed dependencies and built a local copy of the C4 dataset, let's start training!
 
-**Please remember** to edit the `data_remote` and `data_local` paths in your YAML to point to your local C4 copy.
-Our streaming dataloader always streams from `data_remote` -> `data_local`, and if both paths are the same,
-then no extra copying is done.
+**Please remember** to edit the `data_local` and (optionally) `data_remote` paths in your YAML.
+Our streaming dataloader always streams to `data_local` <- from <- `data_remote`, and if the remote path is missing, the files are expected to be present in `data_local`.
 
-**Also remember** that if you only downloaded the `val` split, you need to make sure your train_dataloader is pointed that split.
-Just change `split: train` to `split: val` in your YAML, [e.g. here](./yamls/mosaic_gpt/125m.yaml#L32).
+**Also remember** that if you only downloaded the `train-small` split, you need to make sure your train_loader uses that split. Just change `split: train` to `split: train-small` in your YAML, [e.g. here](./yamls/mosaic_gpt/125m.yaml#L40). Or alternatively, pass it in via CLI arg: `composer main.py ... train_loader.split=train-small`.
 
 
 ### Single-Node training

--- a/llm/README.md
+++ b/llm/README.md
@@ -51,9 +51,9 @@ Here's what you need to get started with our LLM stack:
 
 # Dataset preparation
 To run training, you'll need to make yourself aå copy of the pre-training dataset.
-If you only want to profile these LLMs, we recommend that you **download and prepare the `train-small` and `val` splits**,
-and skip the full `train` split. You'll just need to replace `split: train` with `split: train-small` in your run YAML, [e.g. here](./yamls/mosaic_gpt/125m.yaml#L40).
-You can also accomplish this in your CLI command like so: `composer main.py ... train_loader.split=train-small`
+If you only want to profile these LLMs, we recommend that you **download and prepare the `train_small` and `val` splits**,
+and skip the full `train` split. You'll just need to replace `split: train` with `split: train_small` in your run YAML, [e.g. here](./yamls/mosaic_gpt/125m.yaml#L40).
+You can also accomplish this in your CLI command like so: `composer main.py ... train_loader.split=train_small`
 Alternatively, feel free to substitute our dataloader with one of your own in [main.py](./main.py#L96)!
 
 As an example, we train LLMs on the [C4: Colossal, Cleaned, Common Crawl dataset](https://huggingface.co/datasets/c4).
@@ -66,10 +66,10 @@ You can read more about [the benefits of using mosaicml-streaming here](https://
 ### Converting C4 to streaming dataset `.mds` format
 To make yourself a copy of C4, use `convert_c4.py` like so:
 ```bash
-# Download the 'train-small', 'val' splits and convert to StreamingDataset format
+# Download the 'train_small', 'val' splits and convert to StreamingDataset format
 # This will take 20 sec to 1 min depending on your Internet bandwidth
-# You should see two folders `./my-copy-c4/train-small` and `./my-copy-c4/val` that are each ~0.5GB
-python ../scripts/convert_c4.py --out_root ./my-copy-c4 --splits train-small val
+# You should see two folders `./my-copy-c4/train_small` and `./my-copy-c4/val` that are each ~0.5GB
+python ../scripts/convert_c4.py --out_root ./my-copy-c4 --splits train_small val
 
 # Download the 'train' split if you really want to train the model (not just profile)
 # This will take 1-to-many hours depending on bandwidth, # CPUs, etc.
@@ -104,7 +104,7 @@ Now that you've installed dependencies and built a local copy of the C4 dataset,
 **Please remember** to edit the `data_local` and (optionally) `data_remote` paths in your YAML.
 Our streaming dataloader always streams to `data_local` <- from <- `data_remote`, and if the remote path is missing, the files are expected to be present in `data_local`.
 
-**Also remember** that if you only downloaded the `train-small` split, you need to make sure your train_loader uses that split. Just change `split: train` to `split: train-small` in your YAML, [e.g. here](./yamls/mosaic_gpt/125m.yaml#L40). Or alternatively, pass it in via CLI arg: `composer main.py ... train_loader.split=train-small`.
+**Also remember** that if you only downloaded the `train_small` split, you need to make sure your train_loader uses that split. Just change `split: train` to `split: train_small` in your YAML, [e.g. here](./yamls/mosaic_gpt/125m.yaml#L40). Or alternatively, pass it in via CLI arg: `composer main.py ... train_loader.split=train_small`.
 
 
 ### Single-Node training

--- a/scripts/convert_c4.py
+++ b/scripts/convert_c4.py
@@ -17,7 +17,9 @@ def parse_args() -> Namespace:
     """Parse commandline arguments."""
     args = ArgumentParser()
     args.add_argument('--out_root', type=str, required=True)
-    args.add_argument('--splits', nargs='+', default=['train', 'train-small', 'val'])
+    args.add_argument('--splits',
+                      nargs='+',
+                      default=['train', 'train-small', 'val'])
 
     return args.parse_args()
 
@@ -59,7 +61,8 @@ def build_hf_c4_dataset(split: str) -> IterableDataset:
     return ShardedC4()
 
 
-def generate_samples(dataset: IterableDataset, expected_num_samples: int) -> Iterable[Dict[str, bytes]]:
+def generate_samples(dataset: IterableDataset,
+                     expected_num_samples: int) -> Iterable[Dict[str, bytes]]:
     """Generator over each dataset sample.
 
     Args:
@@ -101,7 +104,6 @@ def generate_samples(dataset: IterableDataset, expected_num_samples: int) -> Ite
                 return
 
 
-
 def main(args: Namespace) -> None:
     """Main: create C4 streaming dataset.
 
@@ -121,10 +123,8 @@ def main(args: Namespace) -> None:
 
         # Get samples
         dataset = build_hf_c4_dataset(split=split)
-        samples = generate_samples(
-                    dataset=dataset,
-                    expected_num_samples=expected_num_samples
-        )
+        samples = generate_samples(dataset=dataset,
+                                   expected_num_samples=expected_num_samples)
 
         # Write samples
         with MDSWriter(dirname=os.path.join(args.out_root, split_new_name),

--- a/scripts/convert_c4.py
+++ b/scripts/convert_c4.py
@@ -17,6 +17,7 @@ def parse_args() -> Namespace:
     """Parse commandline arguments."""
     args = ArgumentParser()
     args.add_argument('--out_root', type=str, required=True)
+    args.add_argument('--compression', type=str, default=None)
     args.add_argument('--splits',
                       nargs='+',
                       default=['train', 'train-small', 'val'])
@@ -128,7 +129,8 @@ def main(args: Namespace) -> None:
 
         # Write samples
         with MDSWriter(dirname=os.path.join(args.out_root, split_new_name),
-                       columns=columns) as out:
+                       columns=columns,
+                       compression=args.compression) as out:
             for sample in tqdm(samples,
                                desc=split_new_name,
                                total=expected_num_samples):

--- a/scripts/convert_c4.py
+++ b/scripts/convert_c4.py
@@ -20,7 +20,7 @@ def parse_args() -> Namespace:
     args.add_argument('--compression', type=str, default=None)
     args.add_argument('--splits',
                       nargs='+',
-                      default=['train', 'train-small', 'val'])
+                      default=['train', 'train_small', 'val'])
 
     return args.parse_args()
 
@@ -115,7 +115,7 @@ def main(args: Namespace) -> None:
 
     for (split, split_new_name, expected_num_samples) in [
         ('train', 'train', 364868892),
-        ('train', 'train-small', 327680),
+        ('train', 'train_small', 327680),
         ('validation', 'val', 364608),
     ]:
         # Only generate the splits requested

--- a/scripts/convert_c4.py
+++ b/scripts/convert_c4.py
@@ -17,7 +17,7 @@ def parse_args() -> Namespace:
     """Parse commandline arguments."""
     args = ArgumentParser()
     args.add_argument('--out_root', type=str, required=True)
-    args.add_argument('--splits', nargs='+', default=['train', 'val'])
+    args.add_argument('--splits', nargs='+', default=['train', 'train-small', 'val'])
 
     return args.parse_args()
 
@@ -59,7 +59,7 @@ def build_hf_c4_dataset(split: str) -> IterableDataset:
     return ShardedC4()
 
 
-def generate_samples(dataset: IterableDataset) -> Iterable[Dict[str, bytes]]:
+def generate_samples(dataset: IterableDataset, expected_num_samples: int) -> Iterable[Dict[str, bytes]]:
     """Generator over each dataset sample.
 
     Args:
@@ -86,6 +86,8 @@ def generate_samples(dataset: IterableDataset) -> Iterable[Dict[str, bytes]]:
         num_workers=num_workers,
         prefetch_factor=prefetch_factor,
     )
+
+    n_samples = 0
     for batch in loader:
         keys = list(batch.keys())
         current_bs = len(batch[keys[0]])
@@ -94,6 +96,10 @@ def generate_samples(dataset: IterableDataset) -> Iterable[Dict[str, bytes]]:
                 key: batch_values[idx].encode('utf-8')
                 for key, batch_values in batch.items()
             }
+            n_samples += 1
+            if n_samples == expected_num_samples:
+                return
+
 
 
 def main(args: Namespace) -> None:
@@ -106,6 +112,7 @@ def main(args: Namespace) -> None:
 
     for (split, split_new_name, expected_num_samples) in [
         ('train', 'train', 364868892),
+        ('train', 'train-small', 327680),
         ('validation', 'val', 364608),
     ]:
         # Only generate the splits requested
@@ -114,7 +121,10 @@ def main(args: Namespace) -> None:
 
         # Get samples
         dataset = build_hf_c4_dataset(split=split)
-        samples = generate_samples(dataset)
+        samples = generate_samples(
+                    dataset=dataset,
+                    expected_num_samples=expected_num_samples
+        )
 
         # Write samples
         with MDSWriter(dirname=os.path.join(args.out_root, split_new_name),


### PR DESCRIPTION
This PR fixes some bugs, and adds a `train_small` split that can be used for demos rather than point the train_loader at `val`. The latter style has been noted as a potential bug by `mosaicml-streaming` team, which they are working on, but we should probably follow the safer convention either way.