### PR TITLE
Remove codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,0 @@
-/bert/ @alextrott16 @dakinggg @dblalock
-/llm/ @vchiley @bmosaicml @abhi-mosaic @dakinggg @dblalock
-/deeplab/ @Landanjs @A-Jacobson @coryMosaicML @dblalock
-/resnet/ @Landanjs @growlix @A-Jacobson @coryMosaicML @dblalock


### PR DESCRIPTION
Based on slack discussion, having mandatory codeowner checks is more trouble than it's worth. I tried making them optional in the repo settings a few days ago but it seems to still add everyone to the PR as long as the CODEOWNERS file exists.

So this PR just removes the CODEOWNERS file.