### PR TITLE
Triton kernel alibi

### DIFF
--- a/llm/src/flash_attn_triton.py
+++ b/llm/src/flash_attn_triton.py
@@ -205,7 +205,7 @@ def _fwd_kernel(
                            float('-inf'))
         if ALIBI:
             alibi_bias_max = 8
-            alibi = (offs_m[:, None] - seqlen_q) - ((start_n + offs_n)[None, :] - seqlen_k)
+            alibi = (offs_m[:, None] - seqlen_q + 1) - ((start_n + offs_n)[None, :] - seqlen_k + 1)
             alibi = -1 * tl.abs(alibi)
             m = (off_h + 1) * (alibi_bias_max / nheads)
             alibi = alibi / pow(2, m)

--- a/llm/src/mosaic_gpt.py
+++ b/llm/src/mosaic_gpt.py
@@ -141,6 +141,7 @@ class TritonFlashCausalAttention(nn.Module):
             bias=True,
             batch_first=True,
             causal=True,
+            alibi=True,
             device=device,
         )
         self.mhsa.out_proj._is_residual = True  # type: ignore


### PR DESCRIPTION
POC; NOT tested; it does run in MosaicGPT; loss starts going down but no convergence runs yet
```
        if ALIBI:
            alibi_bias_max = 8
            alibi = (offs_m[:, None] - seqlen_q + 1) - ((start_n + offs_n)[None, :] - seqlen_k + 1)
            alibi = -1 * tl.abs(alibi)
            m = (off_h + 1) * (alibi_bias_max / nheads)
            alibi = alibi / pow(2, m)
            qk += alibi
```

The above adds alibi to the triton kernel itself so we don't need to take care of it as a mask on the torch side.
Should be slightly faster and should result in faster code since we do not need to load the alibi mask at every kernel launch.

Proposal for similar additions: 
- We can potentially also pass `key_padding_mask` to the kernel
- We can also probably add attn masking for concatenated seq into the kernel itself (using some special concat token or something)