### PR TITLE
Changing dependencies so the repo is pip installable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
 - repo: https://github.com/pycqa/isort
   hooks:
   - id: isort
-  rev: 5.10.1
+  rev: 5.12.0
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.3.0
   hooks:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ packaging>=21,<24
 omegaconf>=2.2.3,<3
 # these are just for text_data.py
 transformers>=4.11,<5
-mosaicml-streaming<0.3.*
+mosaicml-streaming<0.3


### PR DESCRIPTION
Currently when running "pip install ." we get the following error:
```
Processing /workdisk/brandon/examples_fork
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [2 lines of output]
      _project_root: /workdisk/brandon/examples_fork
      error in mosaicml-examples setup command: 'extras_require' must be a dictionary whose values are strings or lists of strings containing valid project/version requirement specifiers.
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```

This is because of a mis-specified dependency on mosaicml-streaming. See here for a related issue:

https://github.com/mosaicml/composer/pull/1919/files