### PR TITLE
Pin setuptools in build requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+# build requirements
+[build-system]
+requires = ["setuptools < 68.0.0"]
+build-backend = "setuptools.build_meta"
 
 # iSort
 [tool.isort]


### PR DESCRIPTION
We ran into an issue in composer where a setuptools release broke pip install from source. This is because pip uses an isolated build environment, which would always install the latest setuptools. In this PR we pin the setuptools version for building the package so that we have control over when to upgrade. Tested `pip install -e .` locally.

See https://github.com/mosaicml/composer/pull/1926.