### PR TITLE
Gated imports

### DIFF
--- a/examples/bert/__init__.py
+++ b/examples/bert/__init__.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 try:
-    # yapf: disable
     import torch
 
+    # yapf: disable
     from examples.bert.src.bert_layers import (BertEmbeddings, BertEncoder,
                                                BertForMaskedLM,
                                                BertForSequenceClassification,

--- a/examples/bert/__init__.py
+++ b/examples/bert/__init__.py
@@ -1,2 +1,60 @@
 # Copyright 2022 MosaicML Examples authors
 # SPDX-License-Identifier: Apache-2.0
+
+try:
+    from examples.bert.src.bert_layers import (BertEmbeddings, BertEncoder,
+                                               BertForMaskedLM,
+                                               BertForSequenceClassification,
+                                               BertGatedLinearUnitMLP,
+                                               BertLayer, BertLMPredictionHead,
+                                               BertModel, BertOnlyMLMHead,
+                                               BertOnlyNSPHead, BertPooler,
+                                               BertPredictionHeadTransform,
+                                               BertSelfOutput,
+                                               BertUnpadAttention,
+                                               BertUnpadSelfAttention)
+    from examples.bert.src.bert_padding import (IndexFirstAxis,
+                                                IndexPutFirstAxis,
+                                                index_first_axis,
+                                                index_put_first_axis, pad_input,
+                                                unpad_input, unpad_input_only)
+    from examples.bert.src.flash_attn_triton import \
+        flash_attn_func as flash_attn_func_bert
+    from examples.bert.src.hf_bert import (create_hf_bert_classification,
+                                           create_hf_bert_mlm)
+    from examples.bert.src.mosaic_bert import (
+        create_mosaic_bert_classification, create_mosaic_bert_mlm)
+except ImportError as e:
+    raise Exception(
+        'Please make sure to pip install .[bert] to get the requirements for the BERT example.'
+    ) from e
+
+__all__ = [
+    'BertEmbeddings',
+    'BertEncoder',
+    'BertForMaskedLM',
+    'BertForSequenceClassification',
+    'BertGatedLinearUnitMLP',
+    'BertLayer',
+    'BertLMPredictionHead',
+    'BertModel',
+    'BertOnlyMLMHead',
+    'BertOnlyNSPHead',
+    'BertPooler',
+    'BertPredictionHeadTransform',
+    'BertSelfOutput',
+    'BertUnpadAttention',
+    'BertUnpadSelfAttention',
+    'IndexFirstAxis',
+    'IndexPutFirstAxis',
+    'index_first_axis',
+    'index_put_first_axis',
+    'pad_input',
+    'unpad_input',
+    'unpad_input_only',
+    'flash_attn_func_bert',
+    'create_hf_bert_classification',
+    'create_hf_bert_mlm',
+    'create_mosaic_bert_classification',
+    'create_mosaic_bert_mlm',
+]

--- a/examples/bert/__init__.py
+++ b/examples/bert/__init__.py
@@ -32,8 +32,14 @@ try:
     from examples.bert.src.mosaic_bert import (
         create_mosaic_bert_classification, create_mosaic_bert_mlm)
 except ImportError as e:
+    try:
+        is_cuda_available = torch.cuda.is_available()
+    except:
+        is_cuda_available = False
+
+    extras = '.[bert]' if is_cuda_available else '.[bert-cpu]'
     raise ImportError(
-        'Please make sure to pip install .[bert] to get the requirements for the BERT example.'
+        f'Please make sure to pip install {extras} to get the requirements for the BERT example.'
     ) from e
 
 __all__ = [

--- a/examples/bert/__init__.py
+++ b/examples/bert/__init__.py
@@ -33,7 +33,7 @@ try:
         create_mosaic_bert_classification, create_mosaic_bert_mlm)
 except ImportError as e:
     try:
-        is_cuda_available = torch.cuda.is_available()
+        is_cuda_available = torch.cuda.is_available()  # type: ignore
     except:
         is_cuda_available = False
 

--- a/examples/bert/__init__.py
+++ b/examples/bert/__init__.py
@@ -32,7 +32,7 @@ try:
     from examples.bert.src.mosaic_bert import (
         create_mosaic_bert_classification, create_mosaic_bert_mlm)
 except ImportError as e:
-    raise Exception(
+    raise ImportError(
         'Please make sure to pip install .[bert] to get the requirements for the BERT example.'
     ) from e
 

--- a/examples/bert/__init__.py
+++ b/examples/bert/__init__.py
@@ -3,6 +3,8 @@
 
 try:
     # yapf: disable
+    import torch
+
     from examples.bert.src.bert_layers import (BertEmbeddings, BertEncoder,
                                                BertForMaskedLM,
                                                BertForSequenceClassification,
@@ -20,8 +22,9 @@ try:
                                                 index_first_axis,
                                                 index_put_first_axis, pad_input,
                                                 unpad_input, unpad_input_only)
-    from examples.bert.src.flash_attn_triton import \
-        flash_attn_func as flash_attn_func_bert
+    if torch.cuda.is_available():
+        from examples.bert.src.flash_attn_triton import \
+            flash_attn_func as flash_attn_func_bert
     from examples.bert.src.hf_bert import (create_hf_bert_classification,
                                            create_hf_bert_mlm)
     from examples.bert.src.mosaic_bert import (
@@ -54,9 +57,8 @@ __all__ = [
     'pad_input',
     'unpad_input',
     'unpad_input_only',
-    'flash_attn_func_bert',
     'create_hf_bert_classification',
     'create_hf_bert_mlm',
     'create_mosaic_bert_classification',
     'create_mosaic_bert_mlm',
-]
+] + (['flash_attn_func_bert'] if torch.cuda.is_available() else [])

--- a/examples/bert/__init__.py
+++ b/examples/bert/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 try:
+    # yapf: disable
     from examples.bert.src.bert_layers import (BertEmbeddings, BertEncoder,
                                                BertForMaskedLM,
                                                BertForSequenceClassification,
@@ -13,6 +14,7 @@ try:
                                                BertSelfOutput,
                                                BertUnpadAttention,
                                                BertUnpadSelfAttention)
+    # yapf: enable
     from examples.bert.src.bert_padding import (IndexFirstAxis,
                                                 IndexPutFirstAxis,
                                                 index_first_axis,

--- a/examples/bert/__init__.py
+++ b/examples/bert/__init__.py
@@ -24,9 +24,9 @@ try:
                                                 unpad_input, unpad_input_only)
     if torch.cuda.is_available():
         from examples.bert.src.flash_attn_triton import \
-            flash_attn_func as flash_attn_func_bert
+            flash_attn_func as flash_attn_func_bert # type: ignore
         from examples.bert.src.flash_attn_triton import \
-            flash_attn_qkvpacked_func as flash_attn_qkvpacked_func_bert
+            flash_attn_qkvpacked_func as flash_attn_qkvpacked_func_bert # type: ignore
     from examples.bert.src.hf_bert import (create_hf_bert_classification,
                                            create_hf_bert_mlm)
     from examples.bert.src.mosaic_bert import (
@@ -63,5 +63,8 @@ __all__ = [
     'create_hf_bert_mlm',
     'create_mosaic_bert_classification',
     'create_mosaic_bert_mlm',
-] + (['flash_attn_func_bert', 'flash_attn_qkvpacked_func_bert']
-     if torch.cuda.is_available() else [])
+
+    # These are commented out because they only exist if CUDA is available
+    # 'flash_attn_func_bert',
+    # 'flash_attn_qkvpacked_func_bert'
+]

--- a/examples/bert/__init__.py
+++ b/examples/bert/__init__.py
@@ -25,6 +25,8 @@ try:
     if torch.cuda.is_available():
         from examples.bert.src.flash_attn_triton import \
             flash_attn_func as flash_attn_func_bert
+        from examples.bert.src.flash_attn_triton import \
+            flash_attn_qkvpacked_func as flash_attn_qkvpacked_func_bert
     from examples.bert.src.hf_bert import (create_hf_bert_classification,
                                            create_hf_bert_mlm)
     from examples.bert.src.mosaic_bert import (
@@ -61,4 +63,5 @@ __all__ = [
     'create_hf_bert_mlm',
     'create_mosaic_bert_classification',
     'create_mosaic_bert_mlm',
-] + (['flash_attn_func_bert'] if torch.cuda.is_available() else [])
+] + (['flash_attn_func_bert', 'flash_attn_qkvpacked_func_bert']
+     if torch.cuda.is_available() else [])

--- a/examples/bert/src/__init__.py
+++ b/examples/bert/src/__init__.py
@@ -1,6 +1,8 @@
 # Copyright 2022 MosaicML Examples authors
 # SPDX-License-Identifier: Apache-2.0
 
+import torch
+
 # yapf: disable
 from examples.bert.src.bert_layers import (BertEmbeddings, BertEncoder,
                                            BertForMaskedLM,
@@ -17,10 +19,13 @@ from examples.bert.src.bert_padding import (IndexFirstAxis, IndexPutFirstAxis,
                                             index_first_axis,
                                             index_put_first_axis, pad_input,
                                             unpad_input, unpad_input_only)
-from examples.bert.src.flash_attn_triton import \
-    flash_attn_func as flash_attn_func_bert
-from examples.bert.src.flash_attn_triton import \
-    flash_attn_qkvpacked_func as flash_attn_qkvpacked_func_bert
+
+if torch.cuda.is_available():
+    from examples.bert.src.flash_attn_triton import \
+        flash_attn_func as flash_attn_func_bert
+    from examples.bert.src.flash_attn_triton import \
+        flash_attn_qkvpacked_func as flash_attn_qkvpacked_func_bert
+
 from examples.bert.src.hf_bert import (create_hf_bert_classification,
                                        create_hf_bert_mlm)
 from examples.bert.src.mosaic_bert import (create_mosaic_bert_classification,
@@ -49,10 +54,9 @@ __all__ = [
     'pad_input',
     'unpad_input',
     'unpad_input_only',
-    'flash_attn_func_bert',
-    'flash_attn_qkvpacked_func_bert',
     'create_hf_bert_classification',
     'create_hf_bert_mlm',
     'create_mosaic_bert_classification',
     'create_mosaic_bert_mlm',
-]
+] + (['flash_attn_func_bert', 'flash_attn_qkvpacked_func_bert']
+     if torch.cuda.is_available() else [])

--- a/examples/bert/src/__init__.py
+++ b/examples/bert/src/__init__.py
@@ -1,2 +1,56 @@
 # Copyright 2022 MosaicML Examples authors
 # SPDX-License-Identifier: Apache-2.0
+
+from examples.bert.src.bert_layers import (BertEmbeddings, BertEncoder,
+                                           BertForMaskedLM,
+                                           BertForSequenceClassification,
+                                           BertGatedLinearUnitMLP, BertLayer,
+                                           BertLMPredictionHead, BertModel,
+                                           BertOnlyMLMHead, BertOnlyNSPHead,
+                                           BertPooler,
+                                           BertPredictionHeadTransform,
+                                           BertSelfOutput, BertUnpadAttention,
+                                           BertUnpadSelfAttention)
+from examples.bert.src.bert_padding import (IndexFirstAxis, IndexPutFirstAxis,
+                                            index_first_axis,
+                                            index_put_first_axis, pad_input,
+                                            unpad_input, unpad_input_only)
+from examples.bert.src.flash_attn_triton import \
+    flash_attn_func as flash_attn_func_bert
+from examples.bert.src.flash_attn_triton import \
+    flash_attn_qkvpacked_func as flash_attn_qkvpacked_func_bert
+from examples.bert.src.hf_bert import (create_hf_bert_classification,
+                                       create_hf_bert_mlm)
+from examples.bert.src.mosaic_bert import (create_mosaic_bert_classification,
+                                           create_mosaic_bert_mlm)
+
+__all__ = [
+    'BertEmbeddings',
+    'BertEncoder',
+    'BertForMaskedLM',
+    'BertForSequenceClassification',
+    'BertGatedLinearUnitMLP',
+    'BertLayer',
+    'BertLMPredictionHead',
+    'BertModel',
+    'BertOnlyMLMHead',
+    'BertOnlyNSPHead',
+    'BertPooler',
+    'BertPredictionHeadTransform',
+    'BertSelfOutput',
+    'BertUnpadAttention',
+    'BertUnpadSelfAttention',
+    'IndexFirstAxis',
+    'IndexPutFirstAxis',
+    'index_first_axis',
+    'index_put_first_axis',
+    'pad_input',
+    'unpad_input',
+    'unpad_input_only',
+    'flash_attn_func_bert',
+    'flash_attn_qkvpacked_func_bert',
+    'create_hf_bert_classification',
+    'create_hf_bert_mlm',
+    'create_mosaic_bert_classification',
+    'create_mosaic_bert_mlm',
+]

--- a/examples/bert/src/__init__.py
+++ b/examples/bert/src/__init__.py
@@ -22,9 +22,9 @@ from examples.bert.src.bert_padding import (IndexFirstAxis, IndexPutFirstAxis,
 
 if torch.cuda.is_available():
     from examples.bert.src.flash_attn_triton import \
-        flash_attn_func as flash_attn_func_bert
+        flash_attn_func as flash_attn_func_bert # type: ignore
     from examples.bert.src.flash_attn_triton import \
-        flash_attn_qkvpacked_func as flash_attn_qkvpacked_func_bert
+        flash_attn_qkvpacked_func as flash_attn_qkvpacked_func_bert # type: ignore
 
 from examples.bert.src.hf_bert import (create_hf_bert_classification,
                                        create_hf_bert_mlm)
@@ -58,5 +58,8 @@ __all__ = [
     'create_hf_bert_mlm',
     'create_mosaic_bert_classification',
     'create_mosaic_bert_mlm',
-] + (['flash_attn_func_bert', 'flash_attn_qkvpacked_func_bert']
-     if torch.cuda.is_available() else [])
+
+    # These are commented out because they only exist if CUDA is available
+    # 'flash_attn_func_bert',
+    # 'flash_attn_qkvpacked_func_bert'
+]

--- a/examples/bert/src/__init__.py
+++ b/examples/bert/src/__init__.py
@@ -1,6 +1,7 @@
 # Copyright 2022 MosaicML Examples authors
 # SPDX-License-Identifier: Apache-2.0
 
+# yapf: disable
 from examples.bert.src.bert_layers import (BertEmbeddings, BertEncoder,
                                            BertForMaskedLM,
                                            BertForSequenceClassification,
@@ -11,6 +12,7 @@ from examples.bert.src.bert_layers import (BertEmbeddings, BertEncoder,
                                            BertPredictionHeadTransform,
                                            BertSelfOutput, BertUnpadAttention,
                                            BertUnpadSelfAttention)
+# yapf: enable
 from examples.bert.src.bert_padding import (IndexFirstAxis, IndexPutFirstAxis,
                                             index_first_axis,
                                             index_put_first_axis, pad_input,

--- a/examples/cifar/__init__.py
+++ b/examples/cifar/__init__.py
@@ -6,7 +6,7 @@ try:
     from examples.cifar.model import ResNetCIFAR, build_composer_resnet_cifar
 except ImportError as e:
     raise ImportError(
-        'Please make sure to pip install .[cifar] to get the requirements for the CIFAR example.'
+        'Please make sure to pip install .[cifar-cpu] to get the requirements for the CIFAR example.'
     ) from e
 
 __all__ = [

--- a/examples/cifar/__init__.py
+++ b/examples/cifar/__init__.py
@@ -6,7 +6,7 @@ try:
     from examples.cifar.model import ResNetCIFAR, build_composer_resnet_cifar
 except ImportError as e:
     raise ImportError(
-        'Please make sure to pip install .[cifar-cpu] to get the requirements for the CIFAR example.'
+        'Please make sure to pip install .[cifar] or .[cifar-cpu] to get the requirements for the CIFAR example.'
     ) from e
 
 __all__ = [

--- a/examples/cifar/__init__.py
+++ b/examples/cifar/__init__.py
@@ -5,7 +5,7 @@ try:
     from examples.cifar.data import StreamingCIFAR, build_cifar10_dataspec
     from examples.cifar.model import ResNetCIFAR, build_composer_resnet_cifar
 except ImportError as e:
-    raise Exception(
+    raise ImportError(
         'Please make sure to pip install .[cifar] to get the requirements for the CIFAR example.'
     ) from e
 

--- a/examples/cifar/__init__.py
+++ b/examples/cifar/__init__.py
@@ -1,2 +1,17 @@
 # Copyright 2022 MosaicML Examples authors
 # SPDX-License-Identifier: Apache-2.0
+
+try:
+    from examples.cifar.data import StreamingCIFAR, build_cifar10_dataspec
+    from examples.cifar.model import ResNetCIFAR, build_composer_resnet_cifar
+except ImportError as e:
+    raise Exception(
+        'Please make sure to pip install .[cifar] to get the requirements for the CIFAR example.'
+    ) from e
+
+__all__ = [
+    'StreamingCIFAR',
+    'build_cifar10_dataspec',
+    'ResNetCIFAR',
+    'build_composer_resnet_cifar',
+]

--- a/examples/common/__init__.py
+++ b/examples/common/__init__.py
@@ -13,7 +13,7 @@ try:
     from examples.common.text_data import (StreamingTextDataset,
                                            build_text_dataloader)
 except ImportError as e:
-    raise Exception(
+    raise ImportError(
         'Please make sure to pip install . to get the common requirements for all examples.'
     ) from e
 

--- a/examples/common/__init__.py
+++ b/examples/common/__init__.py
@@ -1,2 +1,34 @@
 # Copyright 2022 MosaicML Examples authors
 # SPDX-License-Identifier: Apache-2.0
+
+try:
+    from examples.common.builders import (build_algorithm, build_callback,
+                                          build_dataloader, build_logger,
+                                          build_optimizer, build_scheduler)
+    from examples.common.config_utils import (calculate_batch_size_info,
+                                              log_config,
+                                              update_batch_size_info)
+    from examples.common.speed_monitor_w_mfu import (SpeedMonitorMFU,
+                                                     get_gpu_flops_available)
+    from examples.common.text_data import (StreamingTextDataset,
+                                           build_text_dataloader)
+except ImportError as e:
+    raise Exception(
+        'Please make sure to pip install . to get the common requirements for all examples.'
+    ) from e
+
+__all__ = [
+    'build_callback',
+    'build_logger',
+    'build_algorithm',
+    'build_optimizer',
+    'build_scheduler',
+    'build_dataloader',
+    'calculate_batch_size_info',
+    'update_batch_size_info',
+    'log_config',
+    'get_gpu_flops_available',
+    'SpeedMonitorMFU',
+    'StreamingTextDataset',
+    'build_text_dataloader',
+]

--- a/examples/common/builders.py
+++ b/examples/common/builders.py
@@ -1,16 +1,13 @@
 # Copyright 2022 MosaicML Examples authors
 # SPDX-License-Identifier: Apache-2.0
 
-import composer
 from composer import algorithms
-from composer.callbacks import (LRMonitor, MemoryMonitor, OptimizerMonitor,
-                                SpeedMonitor)
+from composer.callbacks import LRMonitor, MemoryMonitor, OptimizerMonitor
 from composer.loggers import WandBLogger
 from composer.optim import DecoupledAdamW
 from composer.optim.scheduler import (ConstantWithWarmupScheduler,
                                       CosineAnnealingWithWarmupScheduler,
                                       LinearWithWarmupScheduler)
-from packaging import version
 
 from examples.common.speed_monitor_w_mfu import SpeedMonitorMFU
 from examples.common.text_data import build_text_dataloader

--- a/examples/deeplab/__init__.py
+++ b/examples/deeplab/__init__.py
@@ -9,7 +9,7 @@ try:
                                              RandomResizePair,
                                              build_ade20k_transformations)
 except ImportError as e:
-    raise Exception(
+    raise ImportError(
         'Please make sure to pip install .[deeplab] to get the requirements for the DeepLab example.'
     ) from e
 

--- a/examples/deeplab/__init__.py
+++ b/examples/deeplab/__init__.py
@@ -1,2 +1,27 @@
 # Copyright 2022 MosaicML Examples authors
 # SPDX-License-Identifier: Apache-2.0
+
+try:
+    from examples.deeplab.data import ADE20k, StreamingADE20k
+    from examples.deeplab.model import build_composer_deeplabv3, deeplabv3
+    from examples.deeplab.transforms import (PadToSize, PhotometricDistoration,
+                                             RandomCropPair, RandomHFlipPair,
+                                             RandomResizePair,
+                                             build_ade20k_transformations)
+except ImportError as e:
+    raise Exception(
+        'Please make sure to pip install .[deeplab] to get the requirements for the DeepLab example.'
+    ) from e
+
+__all__ = [
+    'ADE20k',
+    'StreamingADE20k',
+    'deeplabv3',
+    'build_composer_deeplabv3',
+    'build_ade20k_transformations',
+    'RandomResizePair',
+    'RandomCropPair',
+    'RandomHFlipPair',
+    'PadToSize',
+    'PhotometricDistoration',
+]

--- a/examples/deeplab/__init__.py
+++ b/examples/deeplab/__init__.py
@@ -10,7 +10,7 @@ try:
                                              build_ade20k_transformations)
 except ImportError as e:
     raise ImportError(
-        'Please make sure to pip install .[deeplab] to get the requirements for the DeepLab example.'
+        'Please make sure to pip install .[deeplab] or .[deeplab-cpu] to get the requirements for the DeepLab example.'
     ) from e
 
 __all__ = [

--- a/examples/llm/__init__.py
+++ b/examples/llm/__init__.py
@@ -23,7 +23,7 @@ try:
     from examples.llm.src.tokenizer import (TOKENIZER_REGISTRY, HFTokenizer,
                                             LLMTokenizer)
 except ImportError as e:
-    raise Exception(
+    raise ImportError(
         'Please make sure to pip install .[llm] to get the requirements for the LLM example.'
     ) from e
 

--- a/examples/llm/__init__.py
+++ b/examples/llm/__init__.py
@@ -23,8 +23,14 @@ try:
     from examples.llm.src.tokenizer import (TOKENIZER_REGISTRY, HFTokenizer,
                                             LLMTokenizer)
 except ImportError as e:
+    try:
+        is_cuda_available = torch.cuda.is_available()
+    except:
+        is_cuda_available = False
+
+    extras = '.[llm]' if is_cuda_available else '.[llm-cpu]'
     raise ImportError(
-        'Please make sure to pip install .[llm] to get the requirements for the LLM example.'
+        f'Please make sure to pip install {extras} to get the requirements for the LLM example.'
     ) from e
 
 __all__ = [

--- a/examples/llm/__init__.py
+++ b/examples/llm/__init__.py
@@ -2,11 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 try:
+    import torch
+
     from examples.llm.src.flash_attention import FlashAttention, FlashMHA
-    from examples.llm.src.flash_attn_triton import \
-        flash_attn_func as flash_attn_func_llm
-    from examples.llm.src.flash_attn_triton import \
-        flash_attn_qkvpacked_func as flash_attn_qkvpacked_func_llm
+    if torch.cuda.is_available():
+        from examples.llm.src.flash_attn_triton import \
+            flash_attn_func as flash_attn_func_llm
+        from examples.llm.src.flash_attn_triton import \
+            flash_attn_qkvpacked_func as flash_attn_qkvpacked_func_llm
     from examples.llm.src.hf_causal_lm import (
         ComposerHFCausalLM, hf_get_causal_base_model,
         hf_get_causal_hidden_layers, hf_get_lm_head,
@@ -27,8 +30,6 @@ except ImportError as e:
 __all__ = [
     'FlashAttention',
     'FlashMHA',
-    'flash_attn_func_llm',
-    'flash_attn_qkvpacked_func_llm',
     'hf_get_causal_base_model',
     'hf_get_lm_head',
     'hf_get_causal_hidden_layers',
@@ -47,4 +48,5 @@ __all__ = [
     'LLMTokenizer',
     'HFTokenizer',
     'TOKENIZER_REGISTRY',
-]
+] + (['flash_attn_func_llm', 'flash_attn_qkvpacked_func_llm']
+     if torch.cuda.is_available() else [])

--- a/examples/llm/__init__.py
+++ b/examples/llm/__init__.py
@@ -7,9 +7,9 @@ try:
     from examples.llm.src.flash_attention import FlashAttention, FlashMHA
     if torch.cuda.is_available():
         from examples.llm.src.flash_attn_triton import \
-            flash_attn_func as flash_attn_func_llm
+            flash_attn_func as flash_attn_func_llm # type: ignore
         from examples.llm.src.flash_attn_triton import \
-            flash_attn_qkvpacked_func as flash_attn_qkvpacked_func_llm
+            flash_attn_qkvpacked_func as flash_attn_qkvpacked_func_llm # type: ignore
     from examples.llm.src.hf_causal_lm import (
         ComposerHFCausalLM, hf_get_causal_base_model,
         hf_get_causal_hidden_layers, hf_get_lm_head,
@@ -48,5 +48,8 @@ __all__ = [
     'LLMTokenizer',
     'HFTokenizer',
     'TOKENIZER_REGISTRY',
-] + (['flash_attn_func_llm', 'flash_attn_qkvpacked_func_llm']
-     if torch.cuda.is_available() else [])
+
+    # These are commented out because they only exist if CUDA is available
+    # 'flash_attn_func_llm',
+    # 'flash_attn_qkvpacked_func_llm'
+]

--- a/examples/llm/__init__.py
+++ b/examples/llm/__init__.py
@@ -24,7 +24,7 @@ try:
                                             LLMTokenizer)
 except ImportError as e:
     try:
-        is_cuda_available = torch.cuda.is_available()
+        is_cuda_available = torch.cuda.is_available()  # type: ignore
     except:
         is_cuda_available = False
 

--- a/examples/llm/__init__.py
+++ b/examples/llm/__init__.py
@@ -1,2 +1,50 @@
 # Copyright 2022 MosaicML Examples authors
 # SPDX-License-Identifier: Apache-2.0
+
+try:
+    from examples.llm.src.flash_attention import FlashAttention, FlashMHA
+    from examples.llm.src.flash_attn_triton import \
+        flash_attn_func as flash_attn_func_llm
+    from examples.llm.src.flash_attn_triton import \
+        flash_attn_qkvpacked_func as flash_attn_qkvpacked_func_llm
+    from examples.llm.src.hf_causal_lm import (
+        ComposerHFCausalLM, hf_get_causal_base_model,
+        hf_get_causal_hidden_layers, hf_get_lm_head,
+        hf_get_tied_embedding_weights, prepare_hf_causal_lm_model_for_fsdp)
+    from examples.llm.src.model_registry import COMPOSER_MODEL_REGISTRY
+    from examples.llm.src.mosaic_gpt import (GPTMLP, ComposerMosaicGPT,
+                                             FlashCausalAttention, GPTBlock,
+                                             MosaicGPT, TorchCausalAttention,
+                                             TritonFlashCausalAttention,
+                                             alibi_bias)
+    from examples.llm.src.tokenizer import (TOKENIZER_REGISTRY, HFTokenizer,
+                                            LLMTokenizer)
+except ImportError as e:
+    raise Exception(
+        'Please make sure to pip install .[llm] to get the requirements for the LLM example.'
+    ) from e
+
+__all__ = [
+    'FlashAttention',
+    'FlashMHA',
+    'flash_attn_func_llm',
+    'flash_attn_qkvpacked_func_llm',
+    'hf_get_causal_base_model',
+    'hf_get_lm_head',
+    'hf_get_causal_hidden_layers',
+    'hf_get_tied_embedding_weights',
+    'prepare_hf_causal_lm_model_for_fsdp',
+    'ComposerHFCausalLM',
+    'COMPOSER_MODEL_REGISTRY',
+    'TorchCausalAttention',
+    'FlashCausalAttention',
+    'TritonFlashCausalAttention',
+    'alibi_bias',
+    'GPTMLP',
+    'GPTBlock',
+    'MosaicGPT',
+    'ComposerMosaicGPT',
+    'LLMTokenizer',
+    'HFTokenizer',
+    'TOKENIZER_REGISTRY',
+]

--- a/examples/llm/src/__init__.py
+++ b/examples/llm/src/__init__.py
@@ -7,9 +7,9 @@ from examples.llm.src.flash_attention import FlashAttention, FlashMHA
 
 if torch.cuda.is_available():
     from examples.llm.src.flash_attn_triton import \
-        flash_attn_func as flash_attn_func_llm
+        flash_attn_func as flash_attn_func_llm # type: ignore
     from examples.llm.src.flash_attn_triton import \
-        flash_attn_qkvpacked_func as flash_attn_qkvpacked_func_llm
+        flash_attn_qkvpacked_func as flash_attn_qkvpacked_func_llm # type: ignore
 
 from examples.llm.src.hf_causal_lm import (ComposerHFCausalLM,
                                            hf_get_causal_base_model,
@@ -46,5 +46,8 @@ __all__ = [
     'LLMTokenizer',
     'HFTokenizer',
     'TOKENIZER_REGISTRY',
-] + (['flash_attn_func_llm', 'flash_attn_qkvpacked_func_llm']
-     if torch.cuda.is_available() else [])
+
+    # These are commented out because they only exist if CUDA is available
+    # 'flash_attn_func_llm',
+    # 'flash_attn_qkvpacked_func_llm'
+]

--- a/examples/llm/src/__init__.py
+++ b/examples/llm/src/__init__.py
@@ -1,11 +1,16 @@
 # Copyright 2022 MosaicML Examples authors
 # SPDX-License-Identifier: Apache-2.0
 
+import torch
+
 from examples.llm.src.flash_attention import FlashAttention, FlashMHA
-from examples.llm.src.flash_attn_triton import \
-    flash_attn_func as flash_attn_func_llm
-from examples.llm.src.flash_attn_triton import \
-    flash_attn_qkvpacked_func as flash_attn_qkvpacked_func_llm
+
+if torch.cuda.is_available():
+    from examples.llm.src.flash_attn_triton import \
+        flash_attn_func as flash_attn_func_llm
+    from examples.llm.src.flash_attn_triton import \
+        flash_attn_qkvpacked_func as flash_attn_qkvpacked_func_llm
+
 from examples.llm.src.hf_causal_lm import (ComposerHFCausalLM,
                                            hf_get_causal_base_model,
                                            hf_get_causal_hidden_layers,
@@ -23,8 +28,6 @@ from examples.llm.src.tokenizer import (TOKENIZER_REGISTRY, HFTokenizer,
 __all__ = [
     'FlashAttention',
     'FlashMHA',
-    'flash_attn_func_llm',
-    'flash_attn_qkvpacked_func_llm',
     'hf_get_causal_base_model',
     'hf_get_lm_head',
     'hf_get_causal_hidden_layers',
@@ -43,4 +46,5 @@ __all__ = [
     'LLMTokenizer',
     'HFTokenizer',
     'TOKENIZER_REGISTRY',
-]
+] + (['flash_attn_func_llm', 'flash_attn_qkvpacked_func_llm']
+     if torch.cuda.is_available() else [])

--- a/examples/llm/src/__init__.py
+++ b/examples/llm/src/__init__.py
@@ -1,2 +1,46 @@
 # Copyright 2022 MosaicML Examples authors
 # SPDX-License-Identifier: Apache-2.0
+
+from examples.llm.src.flash_attention import FlashAttention, FlashMHA
+from examples.llm.src.flash_attn_triton import \
+    flash_attn_func as flash_attn_func_llm
+from examples.llm.src.flash_attn_triton import \
+    flash_attn_qkvpacked_func as flash_attn_qkvpacked_func_llm
+from examples.llm.src.hf_causal_lm import (ComposerHFCausalLM,
+                                           hf_get_causal_base_model,
+                                           hf_get_causal_hidden_layers,
+                                           hf_get_lm_head,
+                                           hf_get_tied_embedding_weights,
+                                           prepare_hf_causal_lm_model_for_fsdp)
+from examples.llm.src.model_registry import COMPOSER_MODEL_REGISTRY
+from examples.llm.src.mosaic_gpt import (GPTMLP, ComposerMosaicGPT,
+                                         FlashCausalAttention, GPTBlock,
+                                         MosaicGPT, TorchCausalAttention,
+                                         TritonFlashCausalAttention, alibi_bias)
+from examples.llm.src.tokenizer import (TOKENIZER_REGISTRY, HFTokenizer,
+                                        LLMTokenizer)
+
+__all__ = [
+    'FlashAttention',
+    'FlashMHA',
+    'flash_attn_func_llm',
+    'flash_attn_qkvpacked_func_llm',
+    'hf_get_causal_base_model',
+    'hf_get_lm_head',
+    'hf_get_causal_hidden_layers',
+    'hf_get_tied_embedding_weights',
+    'prepare_hf_causal_lm_model_for_fsdp',
+    'ComposerHFCausalLM',
+    'COMPOSER_MODEL_REGISTRY',
+    'TorchCausalAttention',
+    'FlashCausalAttention',
+    'TritonFlashCausalAttention',
+    'alibi_bias',
+    'GPTMLP',
+    'GPTBlock',
+    'MosaicGPT',
+    'ComposerMosaicGPT',
+    'LLMTokenizer',
+    'HFTokenizer',
+    'TOKENIZER_REGISTRY',
+]

--- a/examples/llm/src/flash_attention.py
+++ b/examples/llm/src/flash_attention.py
@@ -28,6 +28,7 @@ class FlashAttention(nn.Module):
         try:
             from examples.llm.src.flash_attn_triton import \
                 flash_attn_qkvpacked_func
+            del flash_attn_qkvpacked_func
         except ImportError as e:
             raise e
 
@@ -70,6 +71,8 @@ class FlashAttention(nn.Module):
                 heads. Otherwise, ``attn_weights`` are provided separately per head. Note that this flag only has an
                 effect when ``need_weights=True``. Default: ``True`` (i.e. average weights across heads)
         """
+        from examples.llm.src.flash_attn_triton import flash_attn_qkvpacked_func
+
         assert not need_weights and not average_attn_weights
         assert qkv.dtype in [torch.float16, torch.bfloat16]
         assert qkv.is_cuda

--- a/examples/llm/src/flash_attention.py
+++ b/examples/llm/src/flash_attention.py
@@ -14,11 +14,6 @@ import torch.nn as nn
 from einops import rearrange  # type: ignore (reportMissingImports)
 from torch import Tensor
 
-try:
-    from examples.llm.src.flash_attn_triton import flash_attn_qkvpacked_func
-except ImportError as e:
-    raise e
-
 
 class FlashAttention(nn.Module):
     """Implement the scaled dot product attention with softmax.
@@ -30,6 +25,12 @@ class FlashAttention(nn.Module):
     """
 
     def __init__(self, num_heads, softmax_scale=None, device=None, dtype=None):
+        try:
+            from examples.llm.src.flash_attn_triton import \
+                flash_attn_qkvpacked_func
+        except ImportError as e:
+            raise e
+
         super().__init__()
         self.num_heads = num_heads
         self.softmax_scale = softmax_scale

--- a/examples/llm/src/flash_attention.py
+++ b/examples/llm/src/flash_attention.py
@@ -30,7 +30,7 @@ class FlashAttention(nn.Module):
             from examples.llm.src.flash_attn_triton import \
                 flash_attn_qkvpacked_func
             del flash_attn_qkvpacked_func
-        except ImportError as e:
+        except ImportError:
             raise ImportError(
                 'examples was installed without triton support. Please make sure you are in an environment with CUDA available and pip install .[llm]'
             )

--- a/examples/llm/src/flash_attention.py
+++ b/examples/llm/src/flash_attention.py
@@ -25,12 +25,15 @@ class FlashAttention(nn.Module):
     """
 
     def __init__(self, num_heads, softmax_scale=None, device=None, dtype=None):
+        # fail fast if triton is not available
         try:
             from examples.llm.src.flash_attn_triton import \
                 flash_attn_qkvpacked_func
             del flash_attn_qkvpacked_func
         except ImportError as e:
-            raise e
+            raise ImportError(
+                'examples was installed without triton support. Please make sure you are in an environment with CUDA available and pip install .[llm]'
+            )
 
         super().__init__()
         self.num_heads = num_heads

--- a/examples/resnet/__init__.py
+++ b/examples/resnet/__init__.py
@@ -1,9 +1,14 @@
 # Copyright 2022 MosaicML Examples authors
 # SPDX-License-Identifier: Apache-2.0
 
-from examples.resnet.data import (StreamingImageNet, build_imagenet_dataspec,
-                                  check_dataloader)
-from examples.resnet.model import build_composer_resnet
+try:
+    from examples.resnet.data import (StreamingImageNet,
+                                      build_imagenet_dataspec, check_dataloader)
+    from examples.resnet.model import build_composer_resnet
+except ImportError as e:
+    raise ImportError(
+        'Please make sure to pip install .[resnet] to get the requirements for the ResNet example.'
+    ) from e
 
 __all__ = [
     'StreamingImageNet',

--- a/examples/resnet/__init__.py
+++ b/examples/resnet/__init__.py
@@ -7,7 +7,7 @@ try:
     from examples.resnet.model import build_composer_resnet
 except ImportError as e:
     raise ImportError(
-        'Please make sure to pip install .[resnet] to get the requirements for the ResNet example.'
+        'Please make sure to pip install .[resnet] or .[resnet-cpu] to get the requirements for the ResNet example.'
     ) from e
 
 __all__ = [

--- a/examples/resnet/__init__.py
+++ b/examples/resnet/__init__.py
@@ -1,2 +1,13 @@
 # Copyright 2022 MosaicML Examples authors
 # SPDX-License-Identifier: Apache-2.0
+
+from examples.resnet.data import (StreamingImageNet, build_imagenet_dataspec,
+                                  check_dataloader)
+from examples.resnet.model import build_composer_resnet
+
+__all__ = [
+    'StreamingImageNet',
+    'build_imagenet_dataspec',
+    'check_dataloader',
+    'build_composer_resnet',
+]


### PR DESCRIPTION
Manually verified:
- can start training llm on gpu (with all three attn impl options)
- can start training bert on gpu
- can start training bert on cpu
- training bert in a cifar environment raises error

This is what that error looks like
```
(examples-cifar-3.10) danielking@Daniels-MBP bert % composer main.py yamls/test/main.yaml

Traceback (most recent call last):
  File "/Users/danielking/github/examples/examples/bert/__init__.py", line 8, in <module>
    from examples.bert.src.bert_layers import (BertEmbeddings, BertEncoder,
  File "/Users/danielking/github/examples/examples/bert/src/__init__.py", line 7, in <module>
    from examples.bert.src.bert_layers import (BertEmbeddings, BertEncoder,
  File "/Users/danielking/github/examples/examples/bert/src/bert_layers.py", line 44, in <module>
    from einops import rearrange
ModuleNotFoundError: No module named 'einops'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/danielking/github/examples/examples/bert/main.py", line 13, in <module>
    from examples.bert.src.hf_bert import create_hf_bert_mlm
  File "/Users/danielking/github/examples/examples/bert/__init__.py", line 35, in <module>
    raise Exception(
Exception: Please make sure to pip install .[bert] to get the requirements for the BERT example.
ERROR:composer.cli.launcher:Rank 0 crashed with exit code 1.
Waiting up to 30 seconds for all training processes to terminate. Press Ctrl-C to exit immediately.
Global rank 0 (PID 20673) exited with code 1
ERROR:composer.cli.launcher:Global rank 0 (PID 20673) exited with code 1
```

Notes:
- This does not guard against the edge case where two examples have different, but slightly compatible requirements (e.g. example1 has transformers==4.25 and example2 has transformers>4), and the user installs the requirements for example2 and then imports something from example1. It may work, it may crash, it may fail silently. i think actually checking the requirements file against the installed version of all packages and checking for compatibility is likely more work than it is worth, but let me know if you disagree.
- The triton/flash attention imports are guarded with `torch.cuda.is_available()`. This means that we basically prevent someone from installing the cpu requirements (e.g. `pip install .[llm-cpu]`) in an environment with cuda available.