### PR TITLE
Upgrade `llm` example to Composer 0.12.1

### DIFF
--- a/examples/llm/requirements.txt
+++ b/examples/llm/requirements.txt
@@ -1,6 +1,6 @@
 torch==1.13.1
 einops==0.5.0
-mosaicml==0.12.0
+mosaicml==0.12.1
 mosaicml-streaming==0.2.2
 flash-attn==0.2.2
 mosaicml-cli>=0.2.32,<1


### PR DESCRIPTION
Tested with the instructions from the README.md and all seems to be working well. Seeing callbacks logged in console now too... probably a good idea to turn off `memory_monitor` by default in #108 

```
[batch=12/4800]:
         Train trainer/global_step: 11
         Train trainer/batch_idx: 11
         Train memory/alloc_requests: 119197
         Train memory/free_requests: 119088
         Train memory/allocated_mem: 9095214455296
         Train memory/active_mem: 4314857984
         Train memory/inactive_mem: 91258368
         Train memory/reserved_mem: 40017854464
         Train memory/alloc_retries: 1
         Train trainer/device_train_microbatch_size: 16
         Train loss/train/total: 9.5237
         Train metrics/train/LanguageCrossEntropy: 9.5237
         Train metrics/train/Perplexity: 13680.3779
         Train throughput/batches_per_sec: 0.3258
         Train throughput/samples_per_sec: 83.3991
         Train throughput/device/batches_per_sec: 0.1629
         Train throughput/device/samples_per_sec: 41.6996
         Train throughput/tokens_per_sec: 170801.3840
         Train throughput/device/tokens_per_sec: 85400.6920
         Train throughput/flops_per_sec: 167018108782587.3125
         Train throughput/device/flops_per_sec: 83509054391293.6562
         Train throughput/device/mfu: 0.2677
         Train wall_clock/train: 39.0708
         Train wall_clock/val: 0.0000
         Train wall_clock/total: 39.0708
         Train lr-DecoupledAdamW/group0: 0.0001
```