### PR TITLE
Speed monitor supports no cuda

### DIFF
--- a/examples/bert/tests/smoketest_config_glue.yaml
+++ b/examples/bert/tests/smoketest_config_glue.yaml
@@ -27,7 +27,7 @@ save_finetune_checkpoint_folder: ${save_finetune_checkpoint_prefix}/${base_run_n
 # Callbacks
 callbacks:
   lr_monitor: {}
-  # speed_monitor: {}
+  speed_monitor: {}
 
 # Scheduler
 scheduler:

--- a/examples/bert/tests/smoketest_config_main.yaml
+++ b/examples/bert/tests/smoketest_config_main.yaml
@@ -75,6 +75,6 @@ log_to_console: false
 console_log_interval: 1ba
 
 callbacks:
-  # speed_monitor:
-  #   window_size: 500
+  speed_monitor:
+    window_size: 4
   lr_monitor: {}

--- a/examples/bert/yamls/test/glue.yaml
+++ b/examples/bert/yamls/test/glue.yaml
@@ -32,7 +32,7 @@ save_finetune_checkpoint_folder: ${save_finetune_checkpoint_prefix}/${base_run_n
 # Callbacks
 callbacks:
   lr_monitor: {}
-  # speed_monitor: {}
+  speed_monitor: {}
 
 # Scheduler
 scheduler:

--- a/examples/bert/yamls/test/main.yaml
+++ b/examples/bert/yamls/test/main.yaml
@@ -84,6 +84,6 @@ console_log_interval: 1ba
 
 
 callbacks:
-  # speed_monitor:
-  #   window_size: 500
+  speed_monitor:
+    window_size: 5
   lr_monitor: {}

--- a/examples/common/speed_monitor_w_mfu.py
+++ b/examples/common/speed_monitor_w_mfu.py
@@ -126,6 +126,9 @@ def get_gpu_flops_available(state: State):
             f'MFU cannot be calculated and reported. gpu_flops_available can be manually' +\
             f'overridden by setting gpu_flops_available in SpeedMonitorMFU()'
         )
+        # Setting to 0 will disable MFU computation and prevent
+        # the speed monitor from running this helper every batch
+        gpu_flops_available = 0
 
     return gpu_flops_available
 
@@ -178,7 +181,7 @@ class SpeedMonitorMFU(Callback):
 
         # Get available GPU FLOPS
         if self.gpu_flops_available is None:
-            self.gpu_flops_available = get_gpu_flops_available(state) or 0
+            self.gpu_flops_available = get_gpu_flops_available(state)
 
     def batch_end(self, state: State, logger: Logger):
         batch_num_samples = int(

--- a/examples/common/speed_monitor_w_mfu.py
+++ b/examples/common/speed_monitor_w_mfu.py
@@ -92,6 +92,10 @@ __all__ = ['SpeedMonitorMFU']
 def get_gpu_flops_available(state: State):
     gpu_flops_available = None
 
+    # Return 0 if no CUDA device (e.g., when running with CPU only)
+    if not torch.cuda.is_available():
+        return 0
+
     # torch.cuda.get_device_name() ex output: 'NVIDIA A100-SXM4-40GB'
     dev_name = torch.cuda.get_device_name().lower()
     if 'h100-sxm' in dev_name:
@@ -118,8 +122,9 @@ def get_gpu_flops_available(state: State):
 
     if gpu_flops_available is None:
         warnings.warn(
-            f'gpu_flop count not found for {dev_name=} with precision: {state.precision.value}; MFU cannot be calculated and reported. '
-            f'gpu_flops_available can be manually overridden by setting gpu_flops_available in SpeedMonitorMFU()'
+            f'gpu_flop count not found for {dev_name=} with precision: {state.precision.value}; ' +\
+            f'MFU cannot be calculated and reported. gpu_flops_available can be manually' +\
+            f'overridden by setting gpu_flops_available in SpeedMonitorMFU()'
         )
 
     return gpu_flops_available
@@ -172,8 +177,8 @@ class SpeedMonitorMFU(Callback):
         self.batch_start_num_samples = int(state.timestamp.sample)
 
         # Get available GPU FLOPS
-        if not self.gpu_flops_available:
-            self.gpu_flops_available = get_gpu_flops_available(state)
+        if self.gpu_flops_available is None:
+            self.gpu_flops_available = get_gpu_flops_available(state) or 0
 
     def batch_end(self, state: State, logger: Logger):
         batch_num_samples = int(


### PR DESCRIPTION
This adds a simple fix to make `common/speed_monitor_w_mfu.py` work if there is no CUDA device.