### PR TITLE
Upgrade to `mosaicml-streaming==0.2.3`

### DIFF
--- a/examples/bert/requirements.txt
+++ b/examples/bert/requirements.txt
@@ -2,7 +2,7 @@ datasets==2.7.1
 einops==0.5.0
 torch==1.13.1
 mosaicml==0.12.1
-mosaicml-streaming==0.2.2
+mosaicml-streaming==0.2.3
 omegaconf==2.2.3
 transformers==4.25.1
 # need a newer version of triton

--- a/examples/common/text_data.py
+++ b/examples/common/text_data.py
@@ -177,7 +177,7 @@ def build_text_dataloader(cfg: DictConfig, device_batch_size: int):
         download_timeout=cfg.dataset.get('download_timeout', 60),
         validate_hash=cfg.dataset.get('validate_hash', None),
         shuffle_seed=cfg.dataset.get('shuffle_seed', None),
-        num_canonical_nodes=cfg.dataset.get('num_canonical_nodes', None),
+        num_canonical_nodes=cfg.dataset.get('num_canonical_nodes', 128),
         batch_size=device_batch_size)
 
     mlm_probability = cfg.dataset.get('mlm_probability', None)

--- a/examples/llm/requirements.txt
+++ b/examples/llm/requirements.txt
@@ -1,7 +1,7 @@
 torch==1.13.1
 einops==0.5.0
 mosaicml==0.12.1
-mosaicml-streaming==0.2.2
+mosaicml-streaming==0.2.3
 flash-attn==0.2.2
 mosaicml-cli>=0.2.32,<1
 # need a newer version of triton


### PR DESCRIPTION
This PR updates the BERT and LLM examles to use `mosaicml-streaming==0.2.3`.

We also fix an outstanding TODO to set the default value for `num_canonical_nodes` to a high number, as this will determine the shuffling randomness. The rule is "the samples of the first batch come from the first `num_canonical_nodes` shards", and then samples are approximately distributed like that for the rest of the epoch.

I've verified that on 1 node on OCI, the additional load time from `num_canonical_nodes=1 -> num_canonical_nodes=128` for The Pile dataset is <15s. I think this is a reasonable overhead given how long these LLM training runs usually are.

No breaking changes are expected from the minor release, and tests for dataset creation + training are passing. 

<img width="1820" alt="Screenshot 2023-02-06 at 7 52 30 PM" src="https://user-images.githubusercontent.com/77638579/217143990-647b79a5-404a-4693-a4ad-17a92e1f87fa.png">
