### PR TITLE
Fix grad_accum reporting logic

### DIFF
--- a/examples/common/config_utils.py
+++ b/examples/common/config_utils.py
@@ -1,6 +1,7 @@
 # Copyright 2022 MosaicML Examples authors
 # SPDX-License-Identifier: Apache-2.0
 
+import math
 from typing import Union
 
 from composer.utils import dist
@@ -25,7 +26,8 @@ def calculate_batch_size_info(global_batch_size: int,
                 f'will be reduced from {device_microbatch_size} -> {device_batch_size}.'
             )
             device_microbatch_size = device_batch_size
-        device_grad_accum = device_batch_size // device_microbatch_size
+        device_grad_accum = math.ceil(device_batch_size /
+                                      device_microbatch_size)
     else:
         raise ValueError(f'Not sure how to parse {device_microbatch_size=}')
 

--- a/examples/llm/throughput/parse_logs.py
+++ b/examples/llm/throughput/parse_logs.py
@@ -3,6 +3,7 @@
 
 import argparse
 import csv
+import math
 from typing import Any, Dict
 
 from mcli import sdk as msdk
@@ -144,25 +145,44 @@ def parse_run(run) -> Dict[str, Any]:
         hfu_w_attn = mfu_w_attn
 
     return {
-        'Model': model_name,
-        'SeqLen (T)': seq_len,
-        '# GPUs': gpu_num,
-        'GPU': gpu_type,
-        'MFU': round(mfu_w_attn * 100, 2),
-        'HFU': round(hfu_w_attn * 100, 2),
-        'MicroBatchSize': micro_batchsize,
-        'GradAccum': global_train_batch_size // gpu_num // micro_batchsize,
-        'GlobalBatchSize': global_train_batch_size,
-        'Throughput (S/s)': int(throughput),
-        'Throughput (T/s)': int(throughput * seq_len),
-        'Throughput (T/s/GPU)': int(throughput * seq_len / gpu_num),
-        'GlobalBatchSize (T)': global_train_batch_size * seq_len,
-        'Precision': run.config.parameters['precision'],
-        'MP Mode': fsdp_config['mixed_precision'],
-        'Sharding Strategy': fsdp_config['sharding_strategy'],
-        'Activation Checkpointing': activation_checkpointing,
-        'Activation CPUOffload': str(fsdp_config['activation_cpu_offload']),
-        'NumParams': n_params,
+        'Model':
+            model_name,
+        'SeqLen (T)':
+            seq_len,
+        '# GPUs':
+            gpu_num,
+        'GPU':
+            gpu_type,
+        'MFU':
+            round(mfu_w_attn * 100, 2),
+        'HFU':
+            round(hfu_w_attn * 100, 2),
+        'MicroBatchSize':
+            micro_batchsize,
+        'GradAccum':
+            math.ceil(global_train_batch_size / gpu_num / micro_batchsize),
+        'GlobalBatchSize':
+            global_train_batch_size,
+        'Throughput (S/s)':
+            int(throughput),
+        'Throughput (T/s)':
+            int(throughput * seq_len),
+        'Throughput (T/s/GPU)':
+            int(throughput * seq_len / gpu_num),
+        'GlobalBatchSize (T)':
+            global_train_batch_size * seq_len,
+        'Precision':
+            run.config.parameters['precision'],
+        'MP Mode':
+            fsdp_config['mixed_precision'],
+        'Sharding Strategy':
+            fsdp_config['sharding_strategy'],
+        'Activation Checkpointing':
+            activation_checkpointing,
+        'Activation CPUOffload':
+            str(fsdp_config['activation_cpu_offload']),
+        'NumParams':
+            n_params,
     }
 
 

--- a/examples/llm/throughput/parse_logs.py
+++ b/examples/llm/throughput/parse_logs.py
@@ -96,7 +96,7 @@ def parse_run(run) -> Dict[str, Any]:
 
     seq_len = run.config.parameters['max_seq_len']
     global_train_batch_size = run.config.parameters['global_train_batch_size']
-    activation_checkpointing = str(fsdp_config['activation_checkpointing'])
+    activation_checkpointing = fsdp_config['activation_checkpointing']
 
     logs = msdk.get_run_logs(run)
     lines = ''


### PR DESCRIPTION
When we use a `device_train_microbatch_size` that is not a divisor of `device_train_batch_size`, there will be 1 additional smaller microbatch.

The reporting logic (not used in Trainer anywhere, just configs+logs) does not account for this.

The diff in the `parse_logs.py` looks big but it's just the linter reformatting the lines.