### PR TITLE
lower dataset size back down and lower canonical nodes

### DIFF
--- a/examples/bert/tests/smoketest_config_main.yaml
+++ b/examples/bert/tests/smoketest_config_main.yaml
@@ -25,6 +25,7 @@ train_loader:
     predownload: 1000
     shuffle: true
     mlm_probability: *mlm_probability
+    num_canonical_nodes: 8
   drop_last: true
   num_workers: 4
 

--- a/examples/bert/tests/smoketest_config_main.yaml
+++ b/examples/bert/tests/smoketest_config_main.yaml
@@ -41,6 +41,7 @@ eval_loader:
     predownload: 1000
     shuffle: false
     mlm_probability: *mlm_probability
+    num_canonical_nodes: 8
   drop_last: false
   num_workers: 4
 

--- a/examples/bert/tests/utils.py
+++ b/examples/bert/tests/utils.py
@@ -23,7 +23,7 @@ class SynthTextDirectory(object):
         shutil.rmtree(self.path)
 
 
-def create_synthetic_text_dataset(n_samples: int = 128):
+def create_synthetic_text_dataset(n_samples: int = 16):
     tmp_dirname = tempfile.mkdtemp()
 
     for split in ['train', 'val']:

--- a/examples/llm/src/flash_attention.py
+++ b/examples/llm/src/flash_attention.py
@@ -27,8 +27,8 @@ class FlashAttention(nn.Module):
     def __init__(self, num_heads, softmax_scale=None, device=None, dtype=None):
         # fail fast if triton is not available
         try:
-            from flash_attn import \
-                flash_attn_triton  # type: ignore (reportMissingImports) # yapf: disable
+            from flash_attn import flash_attn_triton  # type: ignore
+
             del flash_attn_triton
         except ImportError:
             raise ImportError(

--- a/examples/llm/src/flash_attention.py
+++ b/examples/llm/src/flash_attention.py
@@ -74,8 +74,7 @@ class FlashAttention(nn.Module):
                 heads. Otherwise, ``attn_weights`` are provided separately per head. Note that this flag only has an
                 effect when ``need_weights=True``. Default: ``True`` (i.e. average weights across heads)
         """
-        from flash_attn import \
-            flash_attn_triton  # type: ignore (reportMissingImports)
+        from flash_attn import flash_attn_triton  # type: ignore
 
         assert not need_weights and not average_attn_weights
         assert qkv.dtype in [torch.float16, torch.bfloat16]

--- a/examples/llm/src/flash_attention.py
+++ b/examples/llm/src/flash_attention.py
@@ -12,7 +12,6 @@ from typing import Optional, Tuple
 import torch
 import torch.nn as nn
 from einops import rearrange  # type: ignore (reportMissingImports)
-from flash_attn import flash_attn_triton  # type: ignore (reportMissingImports)
 from torch import Tensor
 
 
@@ -26,6 +25,16 @@ class FlashAttention(nn.Module):
     """
 
     def __init__(self, num_heads, softmax_scale=None, device=None, dtype=None):
+        # fail fast if triton is not available
+        try:
+            from flash_attn import \
+                flash_attn_triton  # type: ignore (reportMissingImports)
+            del flash_attn_triton
+        except ImportError:
+            raise ImportError(
+                'examples was installed without flash attention + triton support. Please make sure you are in an environment with CUDA available and pip install .[llm]'
+            )
+
         super().__init__()
         self.num_heads = num_heads
         self.softmax_scale = softmax_scale
@@ -65,6 +74,9 @@ class FlashAttention(nn.Module):
                 heads. Otherwise, ``attn_weights`` are provided separately per head. Note that this flag only has an
                 effect when ``need_weights=True``. Default: ``True`` (i.e. average weights across heads)
         """
+        from flash_attn import \
+            flash_attn_triton  # type: ignore (reportMissingImports)
+
         assert not need_weights and not average_attn_weights
         assert qkv.dtype in [torch.float16, torch.bfloat16]
         assert qkv.is_cuda

--- a/examples/llm/src/flash_attention.py
+++ b/examples/llm/src/flash_attention.py
@@ -28,7 +28,7 @@ class FlashAttention(nn.Module):
         # fail fast if triton is not available
         try:
             from flash_attn import \
-                flash_attn_triton  # type: ignore (reportMissingImports)
+                flash_attn_triton  # type: ignore (reportMissingImports) # yapf: disable
             del flash_attn_triton
         except ImportError:
             raise ImportError(


### PR DESCRIPTION
- change the bert test dataset size back down to 16 by setting `num_canonical_nodes` smaller
- move flash attention import so the file can still be imported on cpu. verified that llm example can still begin training.