### PR TITLE
De-buffer MosaicBERT alibi

### DIFF
--- a/examples/bert/src/bert_layers.py
+++ b/examples/bert/src/bert_layers.py
@@ -449,7 +449,7 @@ class BertEncoder(nn.Module):
         # [n_heads, max_token_length, max_token_length]
         relative_position = relative_position.unsqueeze(0).expand(
             n_heads, -1, -1)
-        slopes = torch.Tensor(_get_alibi_head_slopes(n_heads), device=device)
+        slopes = torch.Tensor(_get_alibi_head_slopes(n_heads)).to(device)
         alibi = slopes.unsqueeze(1).unsqueeze(1) * -relative_position
         # [1, n_heads, max_token_length, max_token_length]
         alibi = alibi.unsqueeze(0)

--- a/examples/bert/src/bert_layers.py
+++ b/examples/bert/src/bert_layers.py
@@ -419,10 +419,9 @@ class BertEncoder(nn.Module):
              self._current_alibi_size))
         self.rebuild_alibi_tensor(size=config.alibi_starting_size)
 
-    def rebuild_alibi_tensor(
-            self,
-            size: int,
-            device: Optional[Union[torch.device, str]] = None) -> torch.Tensor:
+    def rebuild_alibi_tensor(self,
+                             size: int,
+                             device: Optional[Union[torch.device, str]] = None):
         # Alibi
         # Following https://github.com/ofirpress/attention_with_linear_biases/issues/5 (Implementation 1)
         # In the causal case, you can exploit the fact that softmax is invariant to a uniform translation

--- a/examples/bert/src/bert_layers.py
+++ b/examples/bert/src/bert_layers.py
@@ -414,7 +414,9 @@ class BertEncoder(nn.Module):
         # to a reasonably large size to help pre-allocate CUDA memory.
         # The default `alibi_starting_size` is 512.
         self._current_alibi_size = int(config.alibi_starting_size)
-        self.alibi = None  # About to overwritten in the next line
+        self.alibi = torch.zeros(
+            (1, self.num_attention_heads, self._current_alibi_size,
+             self._current_alibi_size))
         self.rebuild_alibi_tensor(size=config.alibi_starting_size)
 
     def rebuild_alibi_tensor(


### PR DESCRIPTION
Addresses checkpointing/loading complications and weird config naming convention related to ALiBi.

Alters MosaicBERT so that (1)`alibi` is an attribute of the model instead of a registered buffer, and (2) the alibi tensor is rebuilt as needed and is sized according to the longest sequence seen since model initialization.