### PR TITLE
Update Nemo Megatron

### DIFF
--- a/examples/nemo/multi_node.yaml
+++ b/examples/nemo/multi_node.yaml
@@ -6,25 +6,27 @@ gpu_num: 16
 image: nvcr.io/nvidia/nemo:22.11
 
 env_variables:
-    # Configure Python to not buffer stdout and stderr, so output shows up in console immediately
-  - key: PYTHONUNBUFFERED
-    value: '1'
+# Configure Python to not buffer stdout and stderr, so output shows up in console immediately
+- key: PYTHONUNBUFFERED
+  value: '1'
 
 integrations:
-  - integration_type: apt_packages
-    # Install parallel to launch multiple processes per node with rank per process
-    packages:
-      - parallel
+- integration_type: apt_packages
+  # Install parallel to launch multiple processes per node with rank per process
+  packages:
+  - parallel
 
-command: | 
+command: |
   # getting the vocab, merge files for the tokenizer
   wget https://s3.amazonaws.com/models.huggingface.co/bert/gpt2-vocab.json
   wget https://s3.amazonaws.com/models.huggingface.co/bert/gpt2-merges.txt
 
-  # Make sure to prepare and download the training data, as defined in NeMo documentation: https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/stable/nlp/nemo_megatron/gpt/gpt_training.html
+  # Make sure to prepare and download the training data, as defined in NeMo documentation:
+  # https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/stable/nlp/nemo_megatron/gpt/gpt_training.html
 
   # Make sure to update the training dataset path below
-  seq 0 7 | parallel -u \ 'CUDA_VISIBLE_DEVICES={} RANK=$(( $NODE_RANK * 8 + {} )) python3 examples/nlp/language_modeling/megatron_gpt_pretraining.py \
+  seq 0 7 | parallel -u \ 'CUDA_VISIBLE_DEVICES={} RANK=$(( $NODE_RANK * 8 + {} )) \
+  python3 examples/nlp/language_modeling/megatron_gpt_pretraining.py \
   --config-path=/workspace/nemo/examples/nlp/language_modeling/conf/ \
   --config-name=megatron_gpt_config.yaml \
   model.data.data_prefix=[1.0,/your_dataset_path_here/] \

--- a/examples/nemo/multi_node.yaml
+++ b/examples/nemo/multi_node.yaml
@@ -33,9 +33,4 @@ command: |
   model.tokenizer.vocab_file=gpt2-vocab.json \
   model.tokenizer.merge_file=gpt2-merges.txt \
   model.optim.name="fused_adam" \
-  trainer.devices=1 \
-  model.micro_batch_size=32 \
-  model.global_batch_size=2048 \
-  model.max_position_embeddings=1024 \
-  model.encoder_seq_length=32 \
-  model.data.seq_length=32'
+  trainer.devices=1'

--- a/examples/nemo/single_node.yaml
+++ b/examples/nemo/single_node.yaml
@@ -6,16 +6,17 @@ gpu_num: 8
 image: nvcr.io/nvidia/nemo:22.11
 
 env_variables:
-    # Configure Python to not buffer stdout and stderr, so output shows up in console immediately 
-  - key: PYTHONUNBUFFERED
-    value: '1'
+# Configure Python to not buffer stdout and stderr, so output shows up in console immediately
+- key: PYTHONUNBUFFERED
+  value: '1'
 
-command: | 
+command: |
   # Getting the tokenizer vocab and merge files
   wget https://s3.amazonaws.com/models.huggingface.co/bert/gpt2-vocab.json
   wget https://s3.amazonaws.com/models.huggingface.co/bert/gpt2-merges.txt
 
-  # Make sure to prepare and download the training data, as defined in NeMo documentation: https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/stable/nlp/nemo_megatron/gpt/gpt_training.html
+  # Make sure to prepare and download the training data, as defined in NeMo documentation:
+  # https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/stable/nlp/nemo_megatron/gpt/gpt_training.html
 
   # Make sure to update the training dataset path below
   python3 examples/nlp/language_modeling/megatron_gpt_pretraining.py \

--- a/examples/nemo/single_node.yaml
+++ b/examples/nemo/single_node.yaml
@@ -26,6 +26,4 @@ command: |
   model.tokenizer.vocab_file=gpt2-vocab.json \
   model.tokenizer.merge_file=gpt2-merges.txt \
   model.optim.name="fused_adam" \
-  trainer.devices=8 \
-  model.micro_batch_size=32 \
-  model.global_batch_size=2048
+  trainer.devices=8


### PR DESCRIPTION
This change updates the nemo example as follows (from PR #115):

- Fixed a bug in the seq command which launched one process too many, failing the job
- Update to run_name to have an informative default
- Updating base image to latest nemo image 22.11 
- Added comments better document the setup 
- Moved apt install into the integrations section
- Updated a few hyper parameters to ensure successful run

Both YAMLs were tested and ran successfully on r7z2 (tested with @bcui19 's pre-processed data stored at s3://mosaicml-internal-checkpoints-shared/brandon/NeMo/)

Also removed linting issues.