### PR TITLE
Update deeplab

### DIFF
--- a/examples/deeplab/README.md
+++ b/examples/deeplab/README.md
@@ -108,7 +108,7 @@ Here's what you need to get started:
    * The image comes pre-configured with the following dependencies:
       * PyTorch Version: 1.12.1
       * CUDA Version: 11.6
-      * MMCV Version: 1.4.4
+      * MMCV Version: 1.4.8
       * mmsegmentation Version: 0.22.0
       * Python Version: 3.9
       * Ubuntu Version: 20.04
@@ -125,7 +125,7 @@ cd examples
 pip install -e ".[deeplab]"  # or pip install -e ".[deeplab-cpu]" if no NVIDIA GPU
 cd examples/deeplab
 # Note: mmcv-full is not in requirements.txt since it is difficult to install automatically
-# If you are not using the suggested docker image, install mmcv using the instructions at https://mmcv.readthedocs.io/en/latest/get_started/installation.html#install-with-pip
+# If you are not using the suggested docker image, install mmcv using the instructions at https://mmcv.readthedocs.io/en/latest/get_started/installation.html#install-with-pip (we use version 1.4.8)
 ```
 
 ---

--- a/examples/deeplab/data.py
+++ b/examples/deeplab/data.py
@@ -20,8 +20,10 @@ from composer.utils import dist
 from PIL import Image
 from streaming import StreamingDataset
 from torch.utils.data import DataLoader, Dataset
-from transforms import (IMAGENET_CHANNEL_MEAN, IMAGENET_CHANNEL_STD,
-                        build_ade20k_transformations)
+
+from examples.deeplab.transforms import (IMAGENET_CHANNEL_MEAN,
+                                         IMAGENET_CHANNEL_STD,
+                                         build_ade20k_transformations)
 
 __all__ = ['ADE20k', 'StreamingADE20k']
 

--- a/examples/deeplab/requirements.txt
+++ b/examples/deeplab/requirements.txt
@@ -1,3 +1,3 @@
 mosaicml[streaming,wandb]>=0.11.0,<0.13
 omegaconf
-mmsegmentation
+mmsegmentation==0.22.0


### PR DESCRIPTION
- pins mmseg to 0.22.0 (the version in our docker image)
- mentions that our docker image uses mmcv-full 1.4.8
- fixes an import path