### PR TITLE
add metrics to base eval dataloader

### DIFF
--- a/examples/llm/main.py
+++ b/examples/llm/main.py
@@ -74,7 +74,8 @@ def main(cfg):
         eval_loader = Evaluator(label='eval',
                                 dataloader=build_dataloader(
                                     cfg.eval_loader,
-                                    cfg.device_eval_batch_size))
+                                    cfg.device_eval_batch_size),
+                                metric_names=list(model.train_metrics.keys()))
         evaluators.append(eval_loader)
 
     if 'icl_tasks' in cfg:


### PR DESCRIPTION
This fixes the issue with eval metrics showing up as nan in the logs

```
[Eval batch=1283/1425] Eval on eval data
[Eval batch=1425/1425] Eval on eval data:
	 Eval LanguageCrossEntropy: 10.0879
	 Eval Perplexity: 24093.9492
[Eval batch=1/161] Eval on lambada/0-shot data
[Eval batch=17/161] Eval on lambada/0-shot data
[Eval batch=33/161] Eval on lambada/0-shot data
[Eval batch=49/161] Eval on lambada/0-shot data
[Eval batch=65/161] Eval on lambada/0-shot data
[Eval batch=81/161] Eval on lambada/0-shot data
[Eval batch=97/161] Eval on lambada/0-shot data
[Eval batch=113/161] Eval on lambada/0-shot data
[Eval batch=129/161] Eval on lambada/0-shot data
[Eval batch=145/161] Eval on lambada/0-shot data
[Eval batch=161/161] Eval on lambada/0-shot data:
	 Eval LanguageCrossEntropy: 10.0879
	 Eval Perplexity: 24093.9492
	 Eval InContextLearningLMAccuracy: 0.0000
```

Note: `LanguageCrossEntropy` and `Perplexity` are still getting logged for the lambada evaluator. This is strictly an issue with the console logger and I filed a bug on it (https://mosaicml.atlassian.net/browse/CO-1769)