### PR TITLE
Handle expected None case for GPTNeoX

### DIFF
--- a/examples/common/hf_fsdp.py
+++ b/examples/common/hf_fsdp.py
@@ -6,7 +6,7 @@
 import functools
 from typing import Any, Iterable, List
 
-from transformers import PreTrainedModel
+from transformers import GPTNeoXForCausalLM, PreTrainedModel
 
 # helper functions
 
@@ -143,6 +143,10 @@ def prepare_hf_causal_lm_model_for_fsdp(model: PreTrainedModel) -> None:
     }
 
     for mod_name, module in modules.items():
+        if isinstance(model,
+                      GPTNeoXForCausalLM) and mod_name == 'tied_embeddings':
+            # This is expected to have module = None
+            continue
         if module is None:
             raise ValueError(
                 f'Unable to FSDP-wrap this model! `{mod_name}` does not ' +

--- a/examples/common/hf_fsdp.py
+++ b/examples/common/hf_fsdp.py
@@ -6,7 +6,7 @@
 import functools
 from typing import Any, Iterable, List
 
-from transformers import GPTNeoXForCausalLM, PreTrainedModel
+from transformers import PreTrainedModel
 
 # helper functions
 

--- a/examples/common/hf_fsdp.py
+++ b/examples/common/hf_fsdp.py
@@ -63,16 +63,6 @@ def hf_get_causal_base_model(model: PreTrainedModel):
     return findattr(model, decoder_attrs)
 
 
-def hf_get_lm_head(model: PreTrainedModel):
-    """Returns the lm head of the specified HuggingFace model.
-
-    NOTE: Different model configurations have different `lm_head` attribute names.
-        - lm_head: (GPT2LMHeadModel, BloomForCausalLM)
-        - embed_out: (GPTNeoXForCausalLM)
-    """
-    return model.get_output_embeddings()
-
-
 def hf_get_hidden_layers(model: PreTrainedModel):
     """Returns the hidden layers of the specified model.
 
@@ -115,7 +105,7 @@ def prepare_hf_causal_lm_model_for_fsdp(model: PreTrainedModel) -> None:
     """
     causal_base_model = hf_get_causal_base_model(model)
     model_block = hf_get_hidden_layers(model)  # type: ignore
-    lm_head = hf_get_lm_head(model)
+    lm_head = model.get_output_embeddings()
     # some models (OPT) implement .get_input_embeddings for the causal subclass
     # but all of them implement it for the base model
     tied_embeddings = causal_base_model.get_input_embeddings()
@@ -161,7 +151,7 @@ def prepare_hf_enc_dec_model_for_fsdp(model: PreTrainedModel) -> None:
     tied_embeddings = model.get_input_embeddings()
     encoder = model.get_encoder()
     decoder = model.get_decoder()
-    lm_head = hf_get_lm_head(model)
+    lm_head = model.get_output_embeddings()
     # some encoder/decoders have different layers for encoder vs decoder
     encoder_block = hf_get_hidden_layers(encoder)
     decoder_block = hf_get_hidden_layers(decoder)


### PR DESCRIPTION
Was seeing errors from `tied_embedding` module being `None` with GPTNeoX. But, as mentioned in the comments, that is expected. So, I made it not error in that case.