### PR TITLE
pin streaming to <0.2.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ packaging>=21,<23
 omegaconf>=2.2.3,<3
 # these are just for common/text_data.py
 transformers>=4.11,<5
-mosaicml-streaming<0.3
+mosaicml-streaming<0.2.4


### PR DESCRIPTION
the distributed init inside of streaming is causing a failure on the tests. And it probably fails in some other not distributed scenarios too.