### PR TITLE
hf bert yaml fix

### DIFF
--- a/examples/bert/yamls/main/hf-bert-base-uncased.yaml
+++ b/examples/bert/yamls/main/hf-bert-base-uncased.yaml
@@ -26,7 +26,7 @@ model:
     num_attention_heads: 12 # bert-base default
     num_hidden_layers: 12 # bert-base default
     max_position_embedding: 512
-    attention_probs_dropout_prob: 0.0
+    attention_probs_dropout_prob: 0.1 # bert-base default
 
 # Dataloaders
 train_loader:

--- a/examples/bert/yamls/main/mcloud_run_a100_40gb.yaml
+++ b/examples/bert/yamls/main/mcloud_run_a100_40gb.yaml
@@ -98,7 +98,7 @@ parameters:
     weight_decay: 1.0e-5 # Amount of weight decay regularization
 
   algorithms:
-    low_precision_layernorm: {}
+    fused_layernorm: {}
 
   max_duration: 286720000sp # Subsample the training data for ~275M samples
   eval_interval: 2000ba

--- a/examples/bert/yamls/main/mcloud_run_a100_80gb.yaml
+++ b/examples/bert/yamls/main/mcloud_run_a100_80gb.yaml
@@ -97,7 +97,7 @@ parameters:
     weight_decay: 1.0e-5 # Amount of weight decay regularization
 
   algorithms:
-    low_precision_layernorm: {}
+    fused_layernorm: {}
 
   max_duration: 286720000sp # Subsample the training data for ~275M samples
   eval_interval: 2000ba

--- a/examples/bert/yamls/main/mosaic-bert-base-uncased.yaml
+++ b/examples/bert/yamls/main/mosaic-bert-base-uncased.yaml
@@ -71,7 +71,7 @@ optimizer:
   weight_decay: 1.0e-5 # Amount of weight decay regularization
 
 algorithms:
-  low_precision_layernorm: {}
+  fused_layernorm: {}
 
 max_duration: 286720000sp # Subsample the training data for ~275M samples
 eval_interval: 2000ba


### PR DESCRIPTION
There is a small typo in the HF bert yaml that needs to be fixed, namely `attention_probs_dropout_prob: 0.1 # bert-base default`. The repo currently sets dropout to 0.0, which is not the default.

This is my mistake from last week.