### PR TITLE
Fix `key_padding_mask` when using `attn_impl='flash'`

### DIFF
--- a/examples/llm/src/mosaic_gpt.py
+++ b/examples/llm/src/mosaic_gpt.py
@@ -423,7 +423,7 @@ class MosaicGPT(nn.Module):
                                     dtype=x.dtype)
         if self.cfg.attn_impl == 'flash' and key_padding_mask is None:
             mod_key_padding_mask = torch.ones_like(input_ids, dtype=torch.bool)
-        if self.cfg.attn_impl == 'triton':
+        elif self.cfg.attn_impl == 'triton':
             mod_key_padding_mask = None
         else:
             mod_key_padding_mask = key_padding_mask

--- a/examples/llm/src/mosaic_gpt.py
+++ b/examples/llm/src/mosaic_gpt.py
@@ -421,9 +421,9 @@ class MosaicGPT(nn.Module):
                                     seq_len=S,
                                     key_padding_mask=key_padding_mask,
                                     dtype=x.dtype)
-        if cfg.attn_impl == 'flash':
+        if self.cfg.attn_impl == 'flash':
             key_padding_mask = torch.ones_like(input_ids, dtype=torch.bool)
-        if cfg.attn_impl == 'triton':
+        if self.cfg.attn_impl == 'triton':
             key_padding_mask = None
         for block in self.transformer.blocks:  # type: ignore
             x = block(x, key_padding_mask, attn_mask)

--- a/examples/llm/src/mosaic_gpt.py
+++ b/examples/llm/src/mosaic_gpt.py
@@ -422,6 +422,9 @@ class MosaicGPT(nn.Module):
                                     key_padding_mask=key_padding_mask,
                                     dtype=x.dtype)
         if self.cfg.attn_impl == 'flash' and key_padding_mask is None:
+            # HazyResearch FlashMHA appears to use more memory when `key_padding_mask=None`
+            # in certain settings like MosaicGPT-7B. So we always provide a tensor.
+            # See https://github.com/mosaicml/examples/pull/163 for more details.
             mod_key_padding_mask = torch.ones_like(input_ids, dtype=torch.bool)
         elif self.cfg.attn_impl == 'triton':
             mod_key_padding_mask = None

--- a/examples/llm/src/mosaic_gpt.py
+++ b/examples/llm/src/mosaic_gpt.py
@@ -421,10 +421,12 @@ class MosaicGPT(nn.Module):
                                     seq_len=S,
                                     key_padding_mask=key_padding_mask,
                                     dtype=x.dtype)
+        if cfg.attn_impl == 'flash':
+            key_padding_mask = torch.ones_like(input_ids, dtype=torch.bool)
+        if cfg.attn_impl == 'triton':
+            key_padding_mask = None
         for block in self.transformer.blocks:  # type: ignore
-            x = block(
-                x, None if self.cfg.attn_impl == 'triton' else key_padding_mask,
-                attn_mask)
+            x = block(x, key_padding_mask, attn_mask)
         x = self.transformer.ln_f(x)  # type: ignore
         # output embedding weight tied to input embedding
         assert isinstance(self.transformer.wte, nn.Module)  # pyright


### PR DESCRIPTION
When we merged #128 , we removed the codepath by which we always force a padding token `pad_token = eos_token` for tokenizers like GPT2. Since this can lead to silent errors. We also started pretokenizing our data and passing the raw torch tensor to the HF collate fn, rather than a batch created by a HF tokenizer (with `attention_mask` optionally inside).

These changes both lead to our text dataloader batches not producing `attention_mask` anymore with the GPT2 tokenizer, it just produces `None`, since there is no padding possible anymore.

This meant that our `MosaicGPT` class was now receiving `key_padding_mask=None` in all situations, including `attn_impl='flash'`. We had not tested this before because it had never showed up.

Upon initial testing of `attn_impl=flash` up to 3B models, nothing seemed broken, training throughput was fine, and even slightly higher for some models.

Last night, while testing 7B models with the settings in our `throughput/` tables, we noticed that the MFU was significantly worse, and there was a lot of "thrashing" in the memory allocator. 

The `FlashMHA` layer from HazyResearch has a separate codepath when `key_padding_mask=None`: https://github.com/HazyResearch/flash-attention/blob/2dc2a195890d323f6f9e1b74e4667099e6144f79/flash_attn/flash_attention.py#L42

For reasons unknown, this codepath is hurting performance for the larger models. Avoiding this codepath by sending a `key_padding_mask` of all 1s appears to fix the problem.