### PR TITLE
[XS] Fix README `cd`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To get started, either clone or fork this repo and install whichever example\[s\
 git clone https://github.com/mosaicml/examples.git
 cd examples # cd into the repo
 pip install -e ".[llm]"  # or pip install -e ".[llm-cpu]" if no NVIDIA GPU
-cd examples/llm # cd into the specific example's folder
+cd llm # cd into the specific example's folder
 ```
 
 Available examples include `bert`, `cifar`, `llm`, `resnet`, `deeplab`, and `nemo`.


### PR DESCRIPTION
The previous command made it look like `examples/examples/llm` was the path