### PR TITLE
Use round-trip time for `SpeedMonitor`

### DIFF
--- a/examples/common/speed_monitor_w_mfu.py
+++ b/examples/common/speed_monitor_w_mfu.py
@@ -171,7 +171,7 @@ class SpeedMonitorMFU(Callback):
         # Log the throughput
         if len(self.history_wct) == self.history_wct.maxlen:
             world_size = dist.get_world_size()
-            elapsed_batches = len(self.history_samples)
+            elapsed_batches = len(self.history_samples) - 1
             elapsed_samples = int(self.history_samples[-1]) - int(
                 self.history_samples[0])
             elapsed_wct = self.history_wct[-1] - self.history_wct[0]

--- a/examples/common/speed_monitor_w_mfu.py
+++ b/examples/common/speed_monitor_w_mfu.py
@@ -140,11 +140,8 @@ class SpeedMonitorMFU(Callback):
                  window_size: int = 100,
                  gpu_flops_available: Optional[Union[float, int]] = None):
         # Track the batch num samples and wct to compute throughput over a window of batches
-        self.batch_start_num_samples = 0
-        self.batch_start_wct = 0.0
-        self.batch_wct_buffer: Deque[float] = deque(maxlen=window_size)
-        self.batch_num_samples_buffer: Deque[int] = deque(maxlen=window_size)
-        self.window_size = window_size
+        self.history_samples: Deque[float] = deque(maxlen=window_size + 1)
+        self.history_wct: Deque[int] = deque(maxlen=window_size + 1)
 
         self.set_gpu_flops_available = False
         self.gpu_flops_available = gpu_flops_available
@@ -154,52 +151,38 @@ class SpeedMonitorMFU(Callback):
 
     def state_dict(self) -> Dict[str, Any]:
         return {
-            'batch_start_num_samples': self.batch_start_num_samples,
-            'batch_start_wct': self.batch_start_wct,
-            'batch_wct_buffer': self.batch_wct_buffer,
-            'batch_num_samples_buffer': self.batch_num_samples_buffer,
+            'history_samples': self.history_samples,
+            'history_wct': self.history_wct,
             'total_eval_wct': self.total_eval_wct,
         }
 
     def load_state_dict(self, state: Dict[str, Any]) -> None:
-        self.batch_start_num_samples = state['batch_start_num_samples']
-        self.batch_start_wct = state['batch_start_wct']
-        self.batch_wct_buffer = deque(
-            [x for x in state['batch_wct_buffer']],
-            maxlen=self.window_size,
-        )
-        self.batch_num_samples_buffer = deque(
-            [x for x in state['batch_num_samples_buffer']],
-            maxlen=self.window_size,
-        )
+        for x in state['history_samples']:
+            self.history_samples.append(x)
+        for x in state['history_wct']:
+            self.history_wct.append(x)
         self.total_eval_wct = state['total_eval_wct']
 
-    def before_dataloader(self, state: State, logger: Logger) -> None:
+    def init(self, state: State, logger: Logger) -> None:
         del logger  # unused
-        self.batch_start_wct = state.timestamp.total_wct.total_seconds()
-        self.batch_start_num_samples = int(state.timestamp.sample)
-
         # Get available GPU FLOPS
         if self.gpu_flops_available is None:
             self.gpu_flops_available = get_gpu_flops_available(state)
 
     def batch_end(self, state: State, logger: Logger):
-        batch_num_samples = int(
-            state.timestamp.sample) - self.batch_start_num_samples
-        batch_wct = state.timestamp.total_wct.total_seconds(
-        ) - self.batch_start_wct
-
         # Add the new element
-        self.batch_wct_buffer.append(batch_wct)
-        self.batch_num_samples_buffer.append(batch_num_samples)
+        self.history_wct.append(state.timestamp.total_wct.total_seconds())
+        self.history_samples.append(state.timestamp.sample)
 
         # Log the throughput
-        if len(self.batch_num_samples_buffer) == self.window_size:
+        if len(self.history_wct) == self.history_wct.maxlen:
             world_size = dist.get_world_size()
-            batches_per_sec = len(self.batch_num_samples_buffer) / sum(
-                self.batch_wct_buffer)
-            samples_per_sec = sum(self.batch_num_samples_buffer) / sum(
-                self.batch_wct_buffer)
+            elapsed_batches = len(self.history_samples)
+            elapsed_samples = int(self.history_samples[-1]) - int(
+                self.history_samples[0])
+            elapsed_wct = self.history_wct[-1] - self.history_wct[0]
+            batches_per_sec = elapsed_batches / elapsed_wct
+            samples_per_sec = elapsed_samples / elapsed_wct
             dev_batches_per_sec = batches_per_sec / world_size
             dev_samples_per_sec = samples_per_sec / world_size
             logger.log_metrics({'throughput/batches_per_sec': batches_per_sec})
@@ -244,8 +227,7 @@ class SpeedMonitorMFU(Callback):
             'wall_clock/val':
                 self.total_eval_wct,
             'wall_clock/total':
-                (state.timestamp.total_wct.total_seconds() + self.total_eval_wct
-                ),
+                state.timestamp.total_wct.total_seconds() + self.total_eval_wct,
         })
 
     def eval_end(self, state: State, logger: Logger):

--- a/examples/common/speed_monitor_w_mfu.py
+++ b/examples/common/speed_monitor_w_mfu.py
@@ -151,16 +151,10 @@ class SpeedMonitorMFU(Callback):
 
     def state_dict(self) -> Dict[str, Any]:
         return {
-            'history_samples': self.history_samples,
-            'history_wct': self.history_wct,
             'total_eval_wct': self.total_eval_wct,
         }
 
     def load_state_dict(self, state: Dict[str, Any]) -> None:
-        for x in state['history_samples']:
-            self.history_samples.append(x)
-        for x in state['history_wct']:
-            self.history_wct.append(x)
         self.total_eval_wct = state['total_eval_wct']
 
     def init(self, state: State, logger: Logger) -> None:


### PR DESCRIPTION
In situations when heavy callbacks are used on `batch_end`, such as `OptimizerMonitor`, the overhead was not being reflected in the `SpeedMonitor`'s metrics.

This refactor cuts out some of the state variables and makes the logic a bit simpler.

Note that because we only count the timestamps at `batch_end`, if you use a `window_size=N`, it will not log the througput metrics until batch `N+1`