### PR TITLE
revert mcloud yamls back to v0.0.3 version

### DIFF
--- a/examples/llm/mcloud/mcli-1b-custom.yaml
+++ b/examples/llm/mcloud/mcli-1b-custom.yaml
@@ -12,11 +12,9 @@ integrations:
 # to convert and host the full 'train' dataset.
 command: |
   cd examples/examples/llm
-  python ../common/convert_dataset.py --dataset c4 --data_subset en --out_root \
-    ./my-copy-c4 --splits train_small val \
+  python ../common/convert_c4.py --out_root ./my-copy-c4 --splits train_small val \
     --concat_tokens 8192 --tokenizer gpt2 --eos_text '<|endoftext|>'
   composer main.py /mnt/config/parameters.yaml
-
 image: mosaicml/pytorch:1.13.1_cu117-python3.10-ubuntu20.04
 optimization_level: 0
 

--- a/examples/llm/mcloud/mcli-1b.yaml
+++ b/examples/llm/mcloud/mcli-1b.yaml
@@ -12,14 +12,12 @@ integrations:
 # to convert and host the full 'train' dataset.
 command: |
   cd examples/examples/llm
-  python ../common/convert_dataset.py --dataset c4 --data_subset en --out_root \
-    ./my-copy-c4 --splits train_small val \
-    --concat_tokens 8192 --tokenizer gpt2 --eos_text '<|endoftext|>'
+  python ../common/convert_c4.py --out_root ./my-copy-c4 --splits train_small val \
+    --concat_tokens 2048 --tokenizer gpt2 --eos_text '<|endoftext|>'
   composer main.py yamls/mosaic_gpt/1b.yaml \
     train_loader.dataset.split=train_small \
     max_duration=100ba \
     eval_interval=0
-
 image: mosaicml/pytorch:1.13.1_cu117-python3.10-ubuntu20.04
 optimization_level: 0
 


### PR DESCRIPTION
The mcloud yamls should not yet include the updated convert command, because they are pinned to v0.0.3. There aren't any gpus to actually run this right now, but im pretty confident it works. I'm just going back to the version that is on `release/v0.0.3`