### PR TITLE
Make it easier to set custom repos in mcloud

### DIFF
--- a/examples/llm/mcloud/mcli-1b-custom.yaml
+++ b/examples/llm/mcloud/mcli-1b-custom.yaml
@@ -1,10 +1,17 @@
 integrations:
+# To point to MosaicML's public repo:
 - integration_type: git_repo
   git_repo: mosaicml/examples
-  git_branch: v0.0.3 # use your branch
-  # git_commit: # OR use your commit hash
+  git_branch: v0.0.3
   pip_install: -e .[llm]
   ssh_clone: false
+
+# To point to a custom repo:
+# - integration_type: git_repo
+#   git_repo: your/repo
+#   git_branch: your_branch # OR use your commit hash with git_commit
+#   pip_install: -e .[llm]
+
 
 # We are fetching, converting, and training on the 'val' split
 # as it is small and quick to get going for this demo.

--- a/examples/llm/mcloud/mcli-1b-eval.yaml
+++ b/examples/llm/mcloud/mcli-1b-eval.yaml
@@ -1,10 +1,17 @@
 integrations:
+# To point to MosaicML's public repo:
 - integration_type: git_repo
   git_repo: mosaicml/examples
-  git_branch: v0.0.3 # use your branch
-  # git_commit: # OR use your commit hash
+  git_branch: v0.0.3
   pip_install: -e .[llm]
   ssh_clone: false
+
+# To point to a custom repo:
+# - integration_type: git_repo
+#   git_repo: your/repo
+#   git_branch: your_branch # OR use your commit hash with git_commit
+#   pip_install: -e .[llm]
+
 
 command: |
   cd examples/examples/llm/icl_eval

--- a/examples/llm/mcloud/mcli-1b.yaml
+++ b/examples/llm/mcloud/mcli-1b.yaml
@@ -1,10 +1,17 @@
 integrations:
+# To point to MosaicML's public repo:
 - integration_type: git_repo
   git_repo: mosaicml/examples
-  git_branch: v0.0.3 # use your branch
-  # git_commit: # OR use your commit hash
+  git_branch: v0.0.3
   pip_install: -e .[llm]
   ssh_clone: false
+
+# To point to a custom repo:
+# - integration_type: git_repo
+#   git_repo: your/repo
+#   git_branch: your_branch # OR use your commit hash with git_commit
+#   pip_install: -e .[llm]
+
 
 # We are fetching, converting, and training on the 'val' split
 # as it is small and quick to get going for this demo.

--- a/examples/resnet_imagenet/yamls/mcloud_run.yaml
+++ b/examples/resnet_imagenet/yamls/mcloud_run.yaml
@@ -1,14 +1,23 @@
+integrations:
+# To point to MosaicML's public repo:
+- integration_type: git_repo
+  git_repo: mosaicml/examples
+  git_branch: v0.0.3
+  pip_install: -e .[resnet-imagenet]
+  ssh_clone: false
+
+# To point to a custom repo:
+# - integration_type: git_repo
+#   git_repo: your/repo
+#   git_branch: your_branch # OR use your commit hash with git_commit
+#   pip_install: -e .[resnet-imagenet]
+
+
 run_name: resnet_example
 cluster:       # Name of the cluster to use for this run
 gpu_type: a100_40gb # Type of GPU to use
 gpu_num: 8  # Number of GPUs to use
 image: mosaicml/pytorch:1.12.1_cu116-python3.9-ubuntu20.04
-integrations:
-- integration_type: git_repo
-  git_repo: mosaicml/examples
-  git_branch: v0.0.3
-  ssh_clone: false
-  pip_install: -e .[resnet-imagenet]
 
 command: |
   cd examples/examples/resnet_imagenet


### PR DESCRIPTION
`ssh_clone` needs to be `True`(default) if a mcloud user wants to set a custom git repo. To make this less confusing, made two separate git integration blocks in the mcloud yamls