### PR TITLE
MosaicML platform product name update (lower case p FTW!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,10 @@ This repo contains reference examples for training ML models quickly and to high
 
 It currently features the following examples:
 
-- [MosaicML Examples](#mosaicml-examples)
-  - [Installation](#installation)
-  - [Extending an example](#extending-an-example)
-  - [Tests and Linting](#tests-and-linting)
-  - [Overriding Arguments](#overriding-arguments)
-- [Examples](#examples)
-  - [ResNet-50 + ImageNet](#resnet-50--imagenet)
-  - [DeepLabV3 + ADE20k](#deeplabv3--ade20k)
-  - [Large Language Models (LLMs)](#large-language-models-llms)
-  - [BERT](#bert)
+* [ResNet-50 + ImageNet](#resnet-50--imagenet)
+* [DeeplabV3 + ADE20k](#deeplabv3--ade20k)
+* [GPT / Large Language Models](#large-language-models-llms)
+* [BERT](#bert)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,16 @@ This repo contains reference examples for training ML models quickly and to high
 
 It currently features the following examples:
 
-* [ResNet-50 + ImageNet](#resnet-50--imagenet)
-* [DeeplabV3 + ADE20k](#deeplabv3--ade20k)
-* [GPT / Large Language Models](#large-language-models-llms)
-* [BERT](#bert)
+- [MosaicML Examples](#mosaicml-examples)
+  - [Installation](#installation)
+  - [Extending an example](#extending-an-example)
+  - [Tests and Linting](#tests-and-linting)
+  - [Overriding Arguments](#overriding-arguments)
+- [Examples](#examples)
+  - [ResNet-50 + ImageNet](#resnet-50--imagenet)
+  - [DeepLabV3 + ADE20k](#deeplabv3--ade20k)
+  - [Large Language Models (LLMs)](#large-language-models-llms)
+  - [BERT](#bert)
 
 ## Installation
 
@@ -87,7 +93,7 @@ This repo features the following examples, each as their own subdirectory:
 ## ResNet-50 + ImageNet
 <img src="https://assets-global.website-files.com/61fd4eb76a8d78bc0676b47d/62a12d1e4eb9b83915be37a6_r50_overall_pareto.png" alt="drawing" width="500"/>
 
-*Figure 1: Comparison of MosaicML recipes against other results, all measured on 8x A100s on MosaicML Cloud.*
+*Figure 1: Comparison of MosaicML recipes against other results, all measured on 8x A100s on the MosaicML platform.*
 
 Train the [MosaicML ResNet](https://www.mosaicml.com/blog/mosaic-resnet), which is currently the [fastest ResNet50 implementation there is](https://www.mosaicml.com/blog/mlperf-2022) and yields a :sparkles: 7x :sparkles: faster time-to-train than a strong baseline.
 

--- a/examples/bert/README.md
+++ b/examples/bert/README.md
@@ -259,9 +259,9 @@ Before using the configs in `yamls/finetuning/glue/` when running `glue.py`, you
 * `base_run_name` (optional) - Make sure to avoid re-using the same name across multiple runs.
 * `algorithms` (optional) - Make sure to include any architecture-modifying algorithms that were applied to your starting checkpoint model before pre-training. For instance, if you turned on `gated_linear_units` in pre-training, make sure to do so during fine-tuning too!
 
-## Running on the MosaicML Cloud
+## Running on the MosaicML platform
 
-If you have configured a compute cluster to work with the MosaicML Cloud, you can use the `yaml/*/mcloud_run*.yaml` reference YAMLs for examples of how to run pre-training and fine-tuning remotely!
+If you have configured a compute cluster to work with the MosaicML platform, you can use the `yaml/*/mcloud_run*.yaml` reference YAMLs for examples of how to run pre-training and fine-tuning remotely!
 
 Once you have filled in the missing YAML fields (and made any other modifications you want), you can launch pre-training by simply running:
 
@@ -289,7 +289,7 @@ mcli run -f yamls/finetuning/glue/mcloud_run.yaml
 
 ### Multi-node training
 
-To train with high performance on *multi-node* clusters, the easiest way is with MosaicML Cloud ;)
+To train with high performance on *multi-node* clusters, the easiest way is with MosaicML platform ;)
 
 But if you want to try this manually on your own cluster, then just provide a few variables to `composer`, either directly via CLI or via environment variables. Then launch the appropriate command on each node.
 
@@ -357,4 +357,4 @@ If you're reading this, we're still profiling the exact speedup and performance 
 
 If you run into any problems with the code, please file Github issues directly to this repo.
 
-If you want to train BERT-style models on MosaicML Cloud, reach out to us at [demo@mosaicml.com](mailto:demo@mosaicml.com)!
+If you want to train BERT-style models on MosaicML platform, reach out to us at [demo@mosaicml.com](mailto:demo@mosaicml.com)!

--- a/examples/bert/README.md
+++ b/examples/bert/README.md
@@ -289,7 +289,7 @@ mcli run -f yamls/finetuning/glue/mcloud_run.yaml
 
 ### Multi-node training
 
-To train with high performance on *multi-node* clusters, the easiest way is with MosaicML platform ;)
+To train with high performance on *multi-node* clusters, the easiest way is with the MosaicML platform ;)
 
 But if you want to try this manually on your own cluster, then just provide a few variables to `composer`, either directly via CLI or via environment variables. Then launch the appropriate command on each node.
 

--- a/examples/deeplab/README.md
+++ b/examples/deeplab/README.md
@@ -34,7 +34,7 @@ The files in this folder are:
 * `tests/` - A suite of tests to check each training component
 * `yamls/`
   * `deeplabv3.yaml` - Configuration for a DeepLabV3+ training run to be used as the first argument to `main.py`
-  * `mcloud_run.yaml` - yaml to use if running on the [MosaicML Cloud](https://www.mosaicml.com/blog/introducing-mosaicml-cloud)
+  * `mcloud_run.yaml` - yaml to use if running on the [MosaicML platform](https://www.mosaicml.com/blog/introducing-mosaicml-cloud)
 
 Now that you have explored the code, let's jump into the prerequisites for training.
 
@@ -59,9 +59,9 @@ python data.py path/to/data
 python data.py s3://my-bucket/my-dir/data /tmp/path/to/local
 ```
 
-## Get started with the MosaicML Cloud
+## Get started with the MosaicML platform
 
-If you're using the MosaicML cloud, all you need to install is [`mcli`](https://github.com/mosaicml/mosaicml-cli/):
+If you're using the MosaicML platform, all you need to install is [`mcli`](https://mcli.docs.mosaicml.com/):
 
 ```bash
 pip install --upgrade mosaicml-cli
@@ -97,7 +97,7 @@ mcli run -f yamls/mcloud_run.yaml
 
 You're done. You can skip the rest of the instructions except [using Mosaic recipes](#using-mosaic-recipes).
 
-## Get started without the MosaicML Cloud
+## Get started without the MosaicML platform
 
 ### Prerequisites
 
@@ -145,7 +145,7 @@ If training on a single node, the `composer` launcher will autodetect the number
 composer main.py yamls/deeplabv3.yaml
 ```
 
-To train with high performance on multi-node clusters, the easiest way is with MosaicML Cloud ;)
+To train with high performance on multi-node clusters, the easiest way is with the MosaicML platform ;)
 
 But if you really must try this manually on your own cluster, then just provide a few variables to `composer`
 either directly via CLI, or via environment variables that can be read. Then launch the appropriate command on each node:

--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -127,7 +127,7 @@ If training on a single node, the `composer` launcher will autodetect the number
 composer main.py yamls/mosaic_gpt/125m.yaml
 ```
 
-To train with high performance on multi-node clusters, the easiest way is with MosaicML platform ;) Check out the `mcloud/` folder for examples!
+To train with high performance on multi-node clusters, the easiest way is with the MosaicML platform ;) Check out the `mcloud/` folder for examples!
 
 But if you really must try this manually on your own cluster, then just provide a few variables to `composer`
 either directly via CLI, or via environment variables that can be read. Then launch the appropriate command on each node:

--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -19,7 +19,7 @@ You'll find in this folder:
 * `main.py` - a script that builds a [Composer](https://github.com/mosaicml/composer) Trainer and calls `trainer.fit()`.
 * `yamls/` - configs for training compute-optimal LLMs from 125M up to 70B parameters.
 * `throughput/` - data on the throughput of our models on different cluster configurations.
-* `mcloud/` - examples of how to use [MosaicML Cloud](https://www.mosaicml.com/cloud) to seamlessly launch training :)
+* `mcloud/` - examples of how to use [MosaicML platform](https://www.mosaicml.com/platform) to seamlessly launch training :)
 
 
 In the [common](../common) folder, you will also find:
@@ -127,7 +127,7 @@ If training on a single node, the `composer` launcher will autodetect the number
 composer main.py yamls/mosaic_gpt/125m.yaml
 ```
 
-To train with high performance on multi-node clusters, the easiest way is with MosaicML Cloud ;) Check out the `mcloud/` folder for examples!
+To train with high performance on multi-node clusters, the easiest way is with MosaicML platform ;) Check out the `mcloud/` folder for examples!
 
 But if you really must try this manually on your own cluster, then just provide a few variables to `composer`
 either directly via CLI, or via environment variables that can be read. Then launch the appropriate command on each node:
@@ -230,4 +230,4 @@ and may not always work with Auto Grad Accum (but we are working on it!).
 # Contact Us
 If you run into any problems with the code, please file Github issues directly to this repo.
 
-you want train LLMs on MosaicML Cloud, reach out to us at [llm-early-access@mosaicml.com](mailto:llm-early-access@mosaicml.com)!
+you want train LLMs on the MosaicML platform, reach out to us at [llm-early-access@mosaicml.com](mailto:llm-early-access@mosaicml.com)!

--- a/examples/llm/mcloud/README.md
+++ b/examples/llm/mcloud/README.md
@@ -1,8 +1,8 @@
-# Using MosaicML Cloud to train LLMs
+# Using MosaicML platform to train LLMs
 
-This folder contains examples of how to use [MosaicML Cloud](https://www.mosaicml.com/cloud) to launch LLM training runs.
+This folder contains examples of how to use [MosaicML platform](https://www.mosaicml.com/platform) to launch LLM training runs.
 
-Full documentation on MosaicML Cloud can be found at https://mcli.docs.mosaicml.com/.
+Full documentation on MosaicML platform can be found at https://mcli.docs.mosaicml.com/.
 
 ## Using MosaicML Command Line Interface (MCLI) to launch runs
 
@@ -17,8 +17,8 @@ Here's how easy it is to launch an LLM training run with MCLI:
 mcli run -f mcli-1b.yaml --cluster CLUSTER --gpus GPUS --name NAME --follow
 ```
 
-All the details of multi-gpu and multi-node orchestration are handled automatically by MosaicML Cloud. Try it out yourself!
+All the details of multi-gpu and multi-node orchestration are handled automatically by MosaicML platform. Try it out yourself!
 
 ## Using the MosaicML Python SDK to launch runs
-You can also use the [Python SDK](https://mcli.docs.mosaicml.com/en/stable/python/hello_world.html) to launch MosaicML Cloud jobs.
+You can also use the [Python SDK](https://mcli.docs.mosaicml.com/en/stable/python/hello_world.html) to launch MosaicML platform jobs.
 This can be used to programatically sweep hyperparameters or orchestrate training runs within a larger pipeline.

--- a/examples/llm/throughput/README.md
+++ b/examples/llm/throughput/README.md
@@ -2,7 +2,7 @@
 
 # MosaicGPT Training Benchmarks
 
-Benchmark measurements for MosaicGPT models trained on [MosaicML Cloud](https://www.mosaicml.com/cloud), including throughput, MFU, and HFU. Each model is based on optimized configurations of various sizes in the [yamls](../yamls) folder, ranging from a 125m to 70B parameter models.
+Benchmark measurements for MosaicGPT models trained on [MosaicML platform](https://www.mosaicml.com/platform), including throughput, MFU, and HFU. Each model is based on optimized configurations of various sizes in the [yamls](../yamls) folder, ranging from a 125m to 70B parameter models.
 
 To reproduce these results, first:
 ```

--- a/examples/nemo/README.md
+++ b/examples/nemo/README.md
@@ -1,21 +1,21 @@
-# Nemo Megatron (NeMo) on MosaicML Cloud (MCloud)
+# Nemo Megatron (NeMo) on the MosaicML platform
 
-[The MosaicML Cloud (MCloud)](https://www.mosaicml.com/blog/mosaicml-cloud-demo) enables easy training of machine learning (ML) jobs. In this folder, we provide examples for how to run NVIDIA Nemo Megatron (NeMo), a powerful conversational AI toolkit that helps researchers from industry and academia reuse prior work and readily scales up to 1000s of GPUs, on MCloud.
+[The MosaicML platform](https://www.mosaicml.com/blog/mosaicml-cloud-demo) enables easy training of machine learning (ML) jobs. In this folder, we provide examples for how to run NVIDIA Nemo Megatron (NeMo), a powerful conversational AI toolkit that helps researchers from industry and academia reuse prior work and readily scales up to 1000s of GPUs, on the MosaicML platform.
 
 You’ll find in this folder:
 
--   `single_node.yaml` - a script to run a single node GPT NeMo training job on MCloud.
--   `multi_node.yaml` - a script to run a multi-node GPT NeMo training job on MCloud.
+-   `single_node.yaml` - a script to run a single node GPT NeMo training job on the MosaicML platform.
+-   `multi_node.yaml` - a script to run a multi-node GPT NeMo training job on the MosaicML platform.
 
 ## Prerequisites
 
-Here’s what you’ll need to get started with running NeMo on MCloud
+Here’s what you’ll need to get started with running NeMo on the MosaicML platform
 
 -   A docker image with the correctly installed NeMo dependencies (we recommend using `nvcr.io/nvidia/nemo:22.09`).
 -   [A dataset prepared in the expected format](https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/stable/nlp/nemo_megatron/gpt/gpt_training.html#data-download-pre-processing).
 
 ## Starting Training
-We include the `.yaml` files required to run NeMo on MCloud. You just need to fill in the `run_name`, `cluster`, and `your_dataset_path_here` fields in the `.yaml` files. Additionally, other NeMo configs can be modified as usual.
+We include the `.yaml` files required to run NeMo on the MosaicML platform. You just need to fill in the `run_name`, `cluster`, and `your_dataset_path_here` fields in the `.yaml` files. Additionally, other NeMo configs can be modified as usual.
 
 ********************************Single Node Jobs********************************
 
@@ -32,7 +32,7 @@ The logs for a successful training job should look something like:
 
 To run a multi-node job it’s as simple as running `mcli run -f multi_node.yaml`.
 
-Fundamentally, the script relies on using the `parallel` library to create the appropriate number of processes, 8, one per GPU. MCloud sets up the appropriate ENV variables such that NeMo knows the size of the job.
+Fundamentally, the script relies on using the `parallel` library to create the appropriate number of processes, 8, one per GPU. The MosaicML platform sets up the appropriate ENV variables such that NeMo knows the size of the job.
 
 Below are the logs from multi-node training:
 
@@ -41,4 +41,4 @@ Below are the logs from multi-node training:
   <img alt="Logs from multi node NeMo trianing." src="./assets/multi_node.png">
 </picture>
 
-Notice we get approximately linear scaling with the number of GPUs running GPT NeMo jobs on MCloud.
+Notice we get approximately linear scaling with the number of GPUs running GPT NeMo jobs on the MosaicML platform.

--- a/examples/resnet_cifar/README.md
+++ b/examples/resnet_cifar/README.md
@@ -36,13 +36,13 @@ The files in this folder are:
 * `tests/` - A suite of tests to check each training component
 * `yamls/`
   * `resnet56.yaml` - Configuration for a CIFAR ResNet56 training run, to be used as the first argument to `main.py`
-  * `mcloud_run.yaml` - yaml to use if running on the [MosaicML Cloud](https://www.mosaicml.com/blog/introducing-mosaicml-cloud)
+  * `mcloud_run.yaml` - yaml to use if running on the [MosaicML platform](https://www.mosaicml.com/blog/introducing-mosaicml-cloud)
 
 Now that you've explored the code, let's get training.
 
-## Get started with the MosaicML Cloud
+## Get started with the MosaicML platform
 
-If you're using the MosaicML cloud, all you need to install is [`mcli`](https://github.com/mosaicml/mosaicml-cli/):
+If you're using the MosaicML platform, all you need to install is [`mcli`](https://github.com/mosaicml/mosaicml-cli/):
 
 ```bash
 pip install --upgrade mosaicml-cli
@@ -67,11 +67,11 @@ mcli run -f yamls/mcloud_run.yaml
 
 You're done. You can skip the rest of the instructions except [saving and loading checkpoints](#saving-and-loading-checkpoints).
 
-## Get started without the MosaicML Cloud
+## Get started without the MosaicML platform
 
 ### Prerequisites
 
-If you're not using the MosaicML cloud, here's what you need to start training:
+If you're not using the MosaicML platform, here's what you need to start training:
 
 * Docker image with PyTorch 1.12+, e.g. [MosaicML's PyTorch image](https://hub.docker.com/r/mosaicml/pytorch/tags)
   * Recommended tag: `mosaicml/pytorch:1.12.1_cu116-python3.9-ubuntu20.04`

--- a/examples/resnet_imagenet/README.md
+++ b/examples/resnet_imagenet/README.md
@@ -33,7 +33,7 @@ The specific files in this folder are:
 * `tests/` - A suite of tests to check each training component
 * `yamls/`
   * `resnet50.yaml` - Configuration for a ResNet50 training run to be used as the first argument to `main.py`
-  * `mcloud_run.yaml` - yaml to use if running on the [MosaicML Cloud](https://www.mosaicml.com/blog/introducing-mosaicml-cloud)
+  * `mcloud_run.yaml` - yaml to use if running on the [MosaicML platform](https://www.mosaicml.com/blog/introducing-mosaicml-cloud)
 
 Now that you've explored the code, let's get training.
 
@@ -50,9 +50,9 @@ python data.py path/to/data
 python data.py s3://my-bucket/my-dir/data /tmp/path/to/local
 ```
 
-## Get started with the MosaicML Cloud
+## Get started with the MosaicML platform
 
-If you're using the MosaicML cloud, all you need to install is [`mcli`](https://github.com/mosaicml/mosaicml-cli/):
+If you're using the MosaicML platform, all you need to install is [`mcli`](https://mcli.docs.mosaicml.com/):
 
 ```bash
 pip install --upgrade mosaicml-cli
@@ -88,7 +88,7 @@ mcli run -f yamls/mcloud_run.yaml
 
 You're done. You can skip the rest of the instructions except [using Mosaic recipes](#using-mosaic-recipes).
 
-## Get started without the MosaicML Cloud
+## Get started without the MosaicML platform
 
 ### Prerequisites
 
@@ -133,7 +133,7 @@ If training on a single node, the `composer` launcher will autodetect the number
 composer main.py yamls/resnet50.yaml
 ```
 
-To train with high performance on multi-node clusters, the easiest way is with MosaicML Cloud ;)
+To train with high performance on multi-node clusters, the easiest way is with the MosaicML platform ;)
 
 But if you really must try this manually on your own cluster, then just provide a few variables to `composer`
 either directly via CLI, or via environment variables that can be read. Then launch the appropriate command on each node:

--- a/examples/stable_diffusion/README.md
+++ b/examples/stable_diffusion/README.md
@@ -60,8 +60,8 @@ The easiest way to train with new data is to make a new dataset in the same form
 
 To add a non-HuggingFace dataset, create your own dataset that yeilds `image` and `text` pairs and use the `build_hf_image_caption_datapsec` function in `data.py` for guidance regarding tokenization and transformations.
 
-# Using MCLOUD
-This example can be run with MCLOUD by configuring the `cluster` and `gpu_type` parameters in `yamls/mcloud_run.yaml` then running:
+# Using the MosaicML platform
+This example can be run with the MosaicML platform by configuring the `cluster` and `gpu_type` parameters in `yamls/mcloud_run.yaml` then running:
 
 ```bash
 mcli run -f yamls/mcloud_run.yaml


### PR DESCRIPTION
This is a documentation only change, following the latest rebrand of our product.
Changes include:
- "MosaicML Cloud" -> "MosaicML platform"
- Updating link to MCLI from the closed source GitHub repo to the publicly available MCLI docs
- Changing links to marketing site from https://www.mosaicml.com/cloud to https://www.mosaicml.com/platform

Note: there are uses of `mcloud` in file names and folders, I did not address these with this PR.