### PR TITLE
Don't run codeql checks for pull requests

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,9 +14,6 @@ name: "CodeQL"
 on:
   push:
     branches: [ main ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ main ]
   schedule:
     - cron: '0 9 * * 1'  # Every Monday at 09:00 (9:00 AM)
 


### PR DESCRIPTION
* CodeQL checks are taking 30+ min for this repo, disabling them on PR's to increase velocity
* Checks will run Monday at 9am and on pushes to `main`