### PR TITLE
add kernel_check when using alibi

### DIFF
--- a/examples/llm/src/models/mosaic_gpt.py
+++ b/examples/llm/src/models/mosaic_gpt.py
@@ -58,6 +58,9 @@ class MosaicGPT(nn.Module):
         self.alibi = cfg.get('alibi', False)
         self.alibi_bias_max = cfg.get('alibi_bias_max',
                                       8 if self.alibi else None)
+        if self.alibi and cfg.attn_impl not in ['torch', 'triton']:
+            raise NotImplementedError(
+                'alibi only implemented with torch and triton attention.')
         # CogView (https://arxiv.org/abs/2105.13290) and GLM-130B (https://arxiv.org/abs/2210.02414)
         # both report this helping with stabilizing training
         self.embedding_fraction = cfg.get('embedding_fraction', 1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pre-commit>=2.18.1,<3
 pytest>=7.2.1,<8
 pytest_codeblocks>=0.16.1,<0.17
 pytest-cov>=4,<5
-pyright>=1.1.290,<1.2
+pyright==1.1.296
 toml>=0.10.2,<0.11
 packaging>=21,<23
 omegaconf>=2.2.3,<3


### PR DESCRIPTION
alibi only implemented for torch and triton kernels. adding check to validate this.