### PR TITLE
Removes `add_eval_metrics` and just puts them in the relevant constructors

### DIFF
--- a/examples/llm/icl_eval/evaluate_model.py
+++ b/examples/llm/icl_eval/evaluate_model.py
@@ -28,8 +28,6 @@ if __name__ == '__main__':
     composer_model = COMPOSER_MODEL_REGISTRY[cfg.model.name](cfg.model)
     tokenizer = TOKENIZER_REGISTRY[cfg.tokenizer.type](**cfg.tokenizer.args)
     evaluators, logger_keys = build_icl_evaluators(cfg, tokenizer)
-    for evaluator in evaluators:
-        composer_model.add_eval_metrics(evaluator)
 
     in_memory_logger = InMemoryLogger()  # track metrics in the in_memory_logger
     loggers: List[LoggerDestination] = [

--- a/examples/llm/main.py
+++ b/examples/llm/main.py
@@ -137,8 +137,6 @@ def main(cfg):
     if 'icl_tasks' in cfg:
         tokenizer = TOKENIZER_REGISTRY[cfg.tokenizer.type](**cfg.tokenizer.args)
         icl_evaluators, _ = build_icl_evaluators(cfg, tokenizer)
-        for icl_evaluator in icl_evaluators:
-            model.add_eval_metrics(icl_evaluator)
         evaluators.extend(icl_evaluators)
 
     # Optimizer

--- a/examples/llm/src/models/hf/hf_causal_lm.py
+++ b/examples/llm/src/models/hf/hf_causal_lm.py
@@ -3,8 +3,10 @@
 
 """Implements a Hugging Causal LM wrapped inside a :class:`.ComposerModel`."""
 
-from composer.metrics.nlp import (InContextLearningMetric, LanguageCrossEntropy,
-                                  Perplexity)
+from composer.metrics.nlp import (InContextLearningLMAccuracy,
+                                  InContextLearningMetric,
+                                  InContextLearningMultipleChoiceAccuracy,
+                                  LanguageCrossEntropy, Perplexity)
 from omegaconf import DictConfig
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
@@ -44,6 +46,12 @@ class ComposerHFCausalLM(HuggingFaceModelWithZLoss):
             cfg.pretrained_model_name_or_path)
 
         metrics = [LanguageCrossEntropy(len(tokenizer)), Perplexity()]
+        eval_metrics = [
+            LanguageCrossEntropy(len(tokenizer)),
+            Perplexity(),
+            InContextLearningLMAccuracy(),
+            InContextLearningMultipleChoiceAccuracy()
+        ]
 
         init_device = cfg.get('init_device', 'cpu')
         if init_device == 'cpu':
@@ -69,6 +77,7 @@ class ComposerHFCausalLM(HuggingFaceModelWithZLoss):
         composer_model = super().__init__(model=model,
                                           tokenizer=tokenizer,
                                           metrics=metrics,
+                                          eval_metrics=eval_metrics,
                                           z_loss=cfg.get('z_loss', 0.0))
 
         # if cfg.add_rouge:

--- a/examples/llm/src/models/hf/hf_prefix_lm.py
+++ b/examples/llm/src/models/hf/hf_prefix_lm.py
@@ -6,7 +6,10 @@
 from __future__ import annotations
 
 import torch
-from composer.metrics.nlp import LanguageCrossEntropy, MaskedAccuracy
+from composer.metrics.nlp import (InContextLearningLMAccuracy,
+                                  InContextLearningMetric,
+                                  InContextLearningMultipleChoiceAccuracy,
+                                  LanguageCrossEntropy, MaskedAccuracy)
 from omegaconf import DictConfig
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
@@ -103,6 +106,13 @@ class ComposerHFPrefixLM(HuggingFaceModelWithZLoss):
                                  ignore_index=_HF_IGNORE_INDEX),
             MaskedAccuracy(ignore_index=_HF_IGNORE_INDEX)
         ]
+        eval_metrics = [
+            LanguageCrossEntropy(vocab_size=vocab_size,
+                                 ignore_index=_HF_IGNORE_INDEX),
+            MaskedAccuracy(ignore_index=_HF_IGNORE_INDEX),
+            InContextLearningLMAccuracy(),
+            InContextLearningMultipleChoiceAccuracy()
+        ]
 
         # if cfg.add_exact_match:
         #     metrics.append(ExactMatch(ignore_index=_HF_IGNORE_INDEX))
@@ -110,6 +120,7 @@ class ComposerHFPrefixLM(HuggingFaceModelWithZLoss):
         composer_model = super().__init__(model=model,
                                           tokenizer=tokenizer,
                                           metrics=metrics,
+                                          eval_metrics=eval_metrics,
                                           z_loss=cfg.get('z_loss', 0.0))
 
         # if cfg.add_rouge:

--- a/examples/llm/src/models/hf/hf_t5.py
+++ b/examples/llm/src/models/hf/hf_t5.py
@@ -5,10 +5,7 @@
 
 from __future__ import annotations
 
-from composer.metrics.nlp import (InContextLearningLMAccuracy,
-                                  InContextLearningMetric,
-                                  InContextLearningMultipleChoiceAccuracy,
-                                  LanguageCrossEntropy, MaskedAccuracy)
+from composer.metrics.nlp import LanguageCrossEntropy, MaskedAccuracy
 from omegaconf import DictConfig
 from transformers import AutoConfig, AutoTokenizer, T5ForConditionalGeneration
 
@@ -87,9 +84,7 @@ class ComposerHFT5(HuggingFaceModelWithZLoss):
         eval_metrics = [
             LanguageCrossEntropy(vocab_size=vocab_size,
                                  ignore_index=_HF_IGNORE_INDEX),
-            MaskedAccuracy(ignore_index=_HF_IGNORE_INDEX),
-            InContextLearningLMAccuracy(),
-            InContextLearningMultipleChoiceAccuracy()
+            MaskedAccuracy(ignore_index=_HF_IGNORE_INDEX)
         ]
 
         # if cfg.add_exact_match:

--- a/examples/llm/src/models/hf/hf_t5.py
+++ b/examples/llm/src/models/hf/hf_t5.py
@@ -5,7 +5,10 @@
 
 from __future__ import annotations
 
-from composer.metrics.nlp import LanguageCrossEntropy, MaskedAccuracy
+from composer.metrics.nlp import (InContextLearningLMAccuracy,
+                                  InContextLearningMetric,
+                                  InContextLearningMultipleChoiceAccuracy,
+                                  LanguageCrossEntropy, MaskedAccuracy)
 from omegaconf import DictConfig
 from transformers import AutoConfig, AutoTokenizer, T5ForConditionalGeneration
 
@@ -81,6 +84,13 @@ class ComposerHFT5(HuggingFaceModelWithZLoss):
                                  ignore_index=_HF_IGNORE_INDEX),
             MaskedAccuracy(ignore_index=_HF_IGNORE_INDEX)
         ]
+        eval_metrics = [
+            LanguageCrossEntropy(vocab_size=vocab_size,
+                                 ignore_index=_HF_IGNORE_INDEX),
+            MaskedAccuracy(ignore_index=_HF_IGNORE_INDEX),
+            InContextLearningLMAccuracy(),
+            InContextLearningMultipleChoiceAccuracy()
+        ]
 
         # if cfg.add_exact_match:
         #     metrics.append(ExactMatch(ignore_index=_HF_IGNORE_INDEX))
@@ -88,6 +98,7 @@ class ComposerHFT5(HuggingFaceModelWithZLoss):
         composer_model = super().__init__(model=model,
                                           tokenizer=tokenizer,
                                           metrics=metrics,
+                                          eval_metrics=eval_metrics,
                                           z_loss=cfg.get('z_loss', 0.0))
 
         # if cfg.add_rouge:

--- a/examples/llm/src/models/hf/model_wrapper.py
+++ b/examples/llm/src/models/hf/model_wrapper.py
@@ -45,8 +45,13 @@ class HuggingFaceModelWithZLoss(HuggingFaceModel):
                      Union[transformers.PreTrainedTokenizer,
                            transformers.PreTrainedTokenizerFast]] = None,
                  metrics: Optional[List[Metric]] = None,
+                 eval_metrics: Optional[List[Metric]] = None,
                  z_loss: float = 0.0):
-        super().__init__(model, tokenizer, use_logits=True, metrics=metrics)
+        super().__init__(model,
+                         tokenizer,
+                         use_logits=True,
+                         eval_metrics=eval_metrics,
+                         metrics=metrics)
         self.z_loss = float(z_loss)
         if self.z_loss < 0.0:
             raise ValueError(f'z_loss(={z_loss}) cannot be negative.')


### PR DESCRIPTION
Manually tested by running mosaic gpt and gpt neo and confirming that it made it through the first eval with icl metrics.