### PR TITLE
enabling logit scaling

### DIFF
--- a/examples/llm/src/models/mosaic_gpt.py
+++ b/examples/llm/src/models/mosaic_gpt.py
@@ -192,7 +192,12 @@ class MosaicGPT(nn.Module):
         # enables scaling output logits; similar to a softmax "temperature"
         # PaLM paper uses scale 1/sqrt(cfg.d_model)
         if self.cfg.get('logit_scale') is not None:
-            logits *= self.cfg.get('logit_scale')
+            logit_scale = self.cfg.get('logit_scale')
+            if logit_scale == 0:
+                warnings.warn(
+                    f'Multiplying logic scale by {logit_scale=}. This will produce degenerate probabilities.'
+                )
+            logits *= logit_scale
 
         return logits
 

--- a/examples/llm/src/models/mosaic_gpt.py
+++ b/examples/llm/src/models/mosaic_gpt.py
@@ -6,6 +6,7 @@
 Inspired by https://github.com/karpathy/minGPT/blob/master/mingpt/model.py
 """
 
+import math
 import warnings
 from typing import Optional
 
@@ -91,6 +92,20 @@ class MosaicGPT(nn.Module):
         })
         self.transformer.update(
             {'ln_f': nn.LayerNorm(cfg.d_model, device=cfg.init_device)})
+
+        # enables scaling output logits; similar to a softmax "temperature"
+        # PaLM paper uses scale 1/sqrt(cfg.d_model)
+        self.logit_scale = None
+        if self.cfg.get('logit_scale') is not None:
+            logit_scale = self.cfg.get('logit_scale')
+            if isinstance(logit_scale, str):
+                if logit_scale == 'inv_sqrt_d_model':
+                    logit_scale = 1 / math.sqrt(self.cfg.d_model)
+                else:
+                    raise ValueError(
+                        f"{logit_scale=} is not recognized as an option; use numeric value or 'inv_sqrt_d_model'."
+                    )
+            self.logit_scale = logit_scale
 
         if cfg.init_device != 'meta':
             print(
@@ -189,15 +204,12 @@ class MosaicGPT(nn.Module):
         assert isinstance(self.transformer.wte.weight, torch.Tensor)  # pyright
         logits = F.linear(x, self.transformer.wte.weight, None)
 
-        # enables scaling output logits; similar to a softmax "temperature"
-        # PaLM paper uses scale 1/sqrt(cfg.d_model)
-        if self.cfg.get('logit_scale') is not None:
-            logit_scale = self.cfg.get('logit_scale')
-            if logit_scale == 0:
+        if self.logit_scale is not None:
+            if self.logit_scale == 0:
                 warnings.warn(
-                    f'Multiplying logic scale by {logit_scale=}. This will produce uniform (uninformative) outputs.'
+                    f'Multiplying logits by {self.logit_scale=}. This will produce uniform (uninformative) outputs.'
                 )
-            logits *= logit_scale
+            logits *= self.logit_scale
 
         return logits
 

--- a/examples/llm/src/models/mosaic_gpt.py
+++ b/examples/llm/src/models/mosaic_gpt.py
@@ -92,13 +92,6 @@ class MosaicGPT(nn.Module):
         self.transformer.update(
             {'ln_f': nn.LayerNorm(cfg.d_model, device=cfg.init_device)})
 
-        # enables scaling output logits; similar to a softmax "temperature"
-        # PaLM paper uses scale 1/sqrt(cfg.d_model)
-        if cfg.get('logit_scale'):
-            self.register_buffer('logit_scale', torch.Tensor([cfg.logit_scale]))
-        else:
-            self.register_buffer('logit_scale', None)
-
         if cfg.init_device != 'meta':
             print(
                 f'You are using {cfg.init_device=}, but you can also use cfg.init_device="meta" with Composer + FSDP for fast initialization.'
@@ -195,8 +188,12 @@ class MosaicGPT(nn.Module):
         assert isinstance(self.transformer.wte, nn.Module)  # pyright
         assert isinstance(self.transformer.wte.weight, torch.Tensor)  # pyright
         logits = F.linear(x, self.transformer.wte.weight, None)
-        if self.logit_scale is not None:
-            logits *= self.logit_scale
+
+        # enables scaling output logits; similar to a softmax "temperature"
+        # PaLM paper uses scale 1/sqrt(cfg.d_model)
+        if self.cfg.get('logit_scale') is not None:
+            logits *= self.cfg.get('logit_scale')
+
         return logits
 
     # Param Initialization, needed for device='meta' fast initialization

--- a/examples/llm/src/models/param_init_fns.py
+++ b/examples/llm/src/models/param_init_fns.py
@@ -113,6 +113,11 @@ def generic_param_init_fn_(module, cfg, init_fn_):
         if module.out_proj.bias is not None:
             torch.nn.init.zeros_(module.out_proj.bias)
 
+    elif hasattr(module, 'logit_scale'):
+        # base model buffer
+        if module.logit_scale is not None:
+            module.logit_scale.fill_(module.cfg.logit_scale)
+
     else:
         for _ in module.parameters(recurse=False):
             # raise error if uninitialized module has any parameters

--- a/examples/llm/src/models/param_init_fns.py
+++ b/examples/llm/src/models/param_init_fns.py
@@ -113,11 +113,6 @@ def generic_param_init_fn_(module, cfg, init_fn_):
         if module.out_proj.bias is not None:
             torch.nn.init.zeros_(module.out_proj.bias)
 
-    elif hasattr(module, 'logit_scale'):
-        # base model buffer
-        if module.logit_scale is not None:
-            module.logit_scale.fill_(module.cfg.logit_scale)
-
     else:
         for _ in module.parameters(recurse=False):
             # raise error if uninitialized module has any parameters

--- a/examples/llm/tests/test_training.py
+++ b/examples/llm/tests/test_training.py
@@ -46,7 +46,8 @@ def gpt_tiny_cfg(conf_path='yamls/mosaic_gpt/125m.yaml'):
                      not torch.cuda.is_available(),
                      reason='testing with cuda requires GPU')),
 ])
-def test_train(device):
+@pytest.mark.parametrize('logit_scale', [None, 0.036])
+def test_train(device, logit_scale):
     if not os.path.isdir('./my-copy-c4/val'):
         pytest.xfail('c4 dataset not set up as expected')
 
@@ -58,6 +59,8 @@ def test_train(device):
     )
 
     test_cfg = gpt_tiny_cfg(conf_path='yamls/mosaic_gpt/125m.yaml')
+    if logit_scale:
+        test_cfg.model.logit_scale = logit_scale
 
     if device == 'cpu':
         pytest.xfail(

--- a/examples/llm/tests/test_training.py
+++ b/examples/llm/tests/test_training.py
@@ -46,7 +46,7 @@ def gpt_tiny_cfg(conf_path='yamls/mosaic_gpt/125m.yaml'):
                      not torch.cuda.is_available(),
                      reason='testing with cuda requires GPU')),
 ])
-@pytest.mark.parametrize('logit_scale', [None, 0.036])
+@pytest.mark.parametrize('logit_scale', [None, 0.036, 'inv_sqrt_d_model'])
 def test_train(device, logit_scale):
     if not os.path.isdir('./my-copy-c4/val'):
         pytest.xfail('c4 dataset not set up as expected')


### PR DESCRIPTION
enables scaling output logits; similar to a softmax "temperature"
the [PaLM paper](https://arxiv.org/abs/2204.02311) uses scale 1/sqrt(cfg.d_model) (see Sec 5 Weight initialization)


Implantation notes: 
[F.cross_entropy](https://pytorch.org/docs/stable/generated/torch.nn.functional.cross_entropy.html#torch-nn-functional-cross-entropy) does not enable temperature.
Since we'd have to add it to the model anyway, I just made it a buffer so that it'd be part of the model state_dict.