### PR TITLE
updt torch attn cuda bf16 mask

### DIFF
--- a/examples/llm/src/models/layers/attention.py
+++ b/examples/llm/src/models/layers/attention.py
@@ -60,7 +60,9 @@ class TorchCausalAttention(nn.Module):
         # 2. This is is the exact opposite behavior of Huggingface's tokenizers, which use the convention that True denotes tokens
         #   we do want to attend to. See https://huggingface.co/docs/transformers/glossary#attention-mask
         attn_mask.fill_(float('-inf'))
-        attn_mask.triu_(diagonal=1)
+        # attn_mask.triu_(diagonal=1)  # triu_ is not implemented for cuda bf16
+        # TODO: revert back to triu_ when torch supports triu_ for cuda bf16
+        attn_mask.masked_fill_(attn_mask.to(bool).fill_(1).tril_(), 0.)
 
         if alibi:
             device, dtype = attn_mask.device, attn_mask.dtype


### PR DESCRIPTION
```
import torch
s = 512
attn_mask = torch.empty(s, s, device='cuda', dtype=torch.bfloat16)
attn_mask.fill_(float('-inf'))
attn_mask.triu_(diagonal=1)
```
produces error:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: "triu_tril_cuda_template" not implemented for 'BFloat16'
```

It looks like triu_ isn't implemented for bf16.

workaround:
```
import torch
s = 512
attn_mask = torch.empty(s, s, device='cuda', dtype=torch.bfloat16)
attn_mask.fill_(float('-inf'))
attn_mask.masked_fill_(attn_mask.to(bool).fill_(1).tril_(), 0.)
```
outputs:
```
tensor([[0., -inf, -inf,  ..., -inf, -inf, -inf],
        [0., 0., -inf,  ..., -inf, -inf, -inf],
        [0., 0., 0.,  ..., -inf, -inf, -inf],
        ...,
        [0., 0., 0.,  ..., 0., -inf, -inf],
        [0., 0., 0.,  ..., 0., 0., -inf],
        [0., 0., 0.,  ..., 0., 0., 0.]], device='cuda:0', dtype=torch.bfloat16)
```


To verify, using the original code with fp16:
```
import torch
s = 512
attn_mask = torch.empty(s, s, device='cuda', dtype=torch.float16)
attn_mask.fill_(float('-inf'))
attn_mask.triu_(diagonal=1)
```
outputs:
```
tensor([[0., -inf, -inf,  ..., -inf, -inf, -inf],
        [0., 0., -inf,  ..., -inf, -inf, -inf],
        [0., 0., 0.,  ..., -inf, -inf, -inf],
        ...,
        [0., 0., 0.,  ..., 0., -inf, -inf],
        [0., 0., 0.,  ..., 0., 0., -inf],
        [0., 0., 0.,  ..., 0., 0., 0.]], device='cuda:0', dtype=torch.float16)
```


This is only an issue when using `attn_impl: torch` with MixedPrecision set to `PURE` ([the new](https://github.com/mosaicml/composer/pull/2047) `DEFAULT` will also trigger this.)


Issue reported by: @dirkgr of Ai2