### PR TITLE
Implement DeepNorm

### DIFF
--- a/examples/llm/src/models/layers/gpt_blocks.py
+++ b/examples/llm/src/models/layers/gpt_blocks.py
@@ -73,7 +73,7 @@ class GPTBlockPostLN(nn.Module):
         self.mlp = GPTMLP(cfg, device=device)
         self.resid_attn_dropout = nn.Dropout(cfg.resid_pdrop)
         self.resid_mlp_dropout = nn.Dropout(cfg.resid_pdrop)
-        if cfg.get('norm_style', 'post_ln') == 'deepnorm':
+        if cfg.get('param_init_fn', 'default_') == 'deepnorm_':
             # constant for decoder-only models
             # see the paper DeepNet, https://arxiv.org/abs/2203.00555
             self.residual_scale = (2 * cfg.n_layers)**0.25

--- a/examples/llm/src/models/layers/gpt_blocks.py
+++ b/examples/llm/src/models/layers/gpt_blocks.py
@@ -31,7 +31,7 @@ class GPTBlock(nn.Module):
 
     def __init__(self,
                  cfg: DictConfig,
-                 causal_attn_cls: nn.Module,
+                 causal_attn_cls,
                  device: Optional[str] = None):
         super().__init__()
         if cfg.get('alibi', False):
@@ -62,7 +62,7 @@ class GPTBlockPostLN(nn.Module):
 
     def __init__(self,
                  cfg: DictConfig,
-                 causal_attn_cls: nn.Module,
+                 causal_attn_cls,
                  device: Optional[str] = None):
         super().__init__()
         if cfg.get('alibi', False):

--- a/examples/llm/src/models/mosaic_gpt.py
+++ b/examples/llm/src/models/mosaic_gpt.py
@@ -69,7 +69,11 @@ class MosaicGPT(nn.Module):
         # default to PreLN blocks for consistency for now
         # if PostLN ends up being better, switch this default
         gpt_block_type = gpt_blocks.GPTBlock if cfg.get(
-            'norm_style', 'pre_ln') == 'pre_ln' else gpt_blocks.GPTBlockPostLN
+            'norm_location',
+            'pre_ln') == 'pre_ln' else gpt_blocks.GPTBlockPostLN
+        gpt_block_type = gpt_blocks.GPTBlockPostLN if cfg.get(
+            'param_init_fn',
+            'baseline_') == 'deepnorm_' else gpt_blocks.GPTBlock
 
         self.transformer = nn.ModuleDict({
             'wte':

--- a/examples/llm/src/models/mosaic_gpt.py
+++ b/examples/llm/src/models/mosaic_gpt.py
@@ -68,9 +68,11 @@ class MosaicGPT(nn.Module):
 
         # default to PreLN blocks for consistency for now
         # if PostLN ends up being better, switch this default
+        # user can specify using post_ln
         gpt_block_type = gpt_blocks.GPTBlock if cfg.get(
             'norm_location',
             'pre_ln') == 'pre_ln' else gpt_blocks.GPTBlockPostLN
+        # or, if the initialization is DeepNorm, know we have to use PostLN
         gpt_block_type = gpt_blocks.GPTBlockPostLN if cfg.get(
             'param_init_fn',
             'baseline_') == 'deepnorm_' else gpt_blocks.GPTBlock

--- a/examples/llm/src/models/param_init_fns.py
+++ b/examples/llm/src/models/param_init_fns.py
@@ -314,38 +314,21 @@ def deepnorm_init_fn_(module, cfg):
 
     elif isinstance(module, nn.Embedding):
         # Embedding
+        # DeepNet paper doesn't mention what they used, so assume PyTorch default
+        emb_init_fn_ = partial(torch.nn.init.normal_, mean=0.0, std=1)
         if cfg.get('emb_init_std') is not None:
-            std = cfg.get('emb_init_std')
-            if std == 0:
-                warnings.warn(f'Embedding layer initialized to 0.')
-            emb_init_fn_ = partial(torch.nn.init.normal_, mean=0.0, std=std)
-            if cfg.get('verbose', 0) > 1:
-                warnings.warn(
-                    f'Embedding layer initialized using normal distribution with mean=0 and {std=}.'
-                )
+            warnings.warn(
+                f'emb_init_std ignored when using param_init_fn: deepnorm_')
         elif cfg.get('emb_init_uniform_lim') is not None:
-            lim = cfg.get('emb_init_uniform_lim')
-            if isinstance(lim, Sequence):
-                if len(lim) > 2:
-                    raise ValueError(
-                        f'Uniform init requires a min and a max limit. User input: {lim}.'
-                    )
-                if lim[0] == lim[1]:
-                    warnings.warn(f'Embedding layer initialized to {lim[0]}.')
-            else:
-                if lim == 0:
-                    warnings.warn(f'Embedding layer initialized to 0.')
-                lim = [-lim, lim]
-            a, b = lim
-            emb_init_fn_ = partial(torch.nn.init.uniform_, a=a, b=b)
-            if cfg.get('verbose', 0) > 1:
-                warnings.warn(
-                    f'Embedding layer initialized using uniform distribution in range {lim}.'
-                )
-        else:
-            emb_init_fn_ = fvo_init_fn_  # deepnet paper does not mention embedding init
+            warnings.warn(
+                f'emb_init_uniform_lim ignored when using param_init_fn: deepnorm_'
+            )
 
         emb_init_fn_(module.weight)
+        if cfg.get('verbose', 0) > 1:
+            warnings.warn(
+                'Embedding layer initialized using normal distribution with mean=0 and std=1.'
+            )
 
     elif isinstance(module, nn.LayerNorm):
         # LayerNorm

--- a/examples/llm/tests/test_init_fn.py
+++ b/examples/llm/tests/test_init_fn.py
@@ -71,6 +71,7 @@ def test_fused_init_helper(fused):
     cfg = om.create({
         'in_features': in_features,
         'out_features': out_features,
+        'n_layers': 2,
     })
 
     fc = nn.Linear(cfg.in_features, cfg.out_features, bias=True)
@@ -117,7 +118,9 @@ def test_all_params_init(module):
 
     module.apply(
         partial(generic_param_init_fn_,
-                cfg=om.create({}),
+                cfg=om.create({
+                    'n_layers': 2,
+                }),
                 init_fn_=max_fill_init_))
     for n, p in module.named_parameters():
         if n == 'bias':


### PR DESCRIPTION
## DeepNorm!
<img src="https://i.ytimg.com/vi/psDbaEkbNFY/maxresdefault.jpg" width="300"/>

This PR:
* adds `GPTBlockPostLN`, which is a PostLN block (we have been using PreLN) 
![image](https://user-images.githubusercontent.com/7231205/224452488-a6f6924e-7096-4802-8e82-2d7dd300a774.png)
* adds a config, `model.norm_location`, which defaults to `pre_ln`, but if is set otherwise, causes us to use `GPTBlockPostLN` instead of `GPTBlock`
* adds a new initialization registry value for the config `param_init_fn`, `deepnorm_`, which uses DeepNorm initialization from the [DeepNet](https://arxiv.org/abs/2203.00555) paper
* if `param_init_fn: deepnorm_` then we also use `GPTBlockPostLN`
