### PR TITLE
Add prefix lm option to MosaicGPT

### DIFF
--- a/examples/llm/src/models/hf/hf_prefix_lm.py
+++ b/examples/llm/src/models/hf/hf_prefix_lm.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import torch
 from composer.metrics.nlp import LanguageCrossEntropy, MaskedAccuracy
 from omegaconf import DictConfig
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
@@ -13,6 +12,7 @@ from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 from examples.llm.src.models.hf.model_wrapper import HuggingFaceModelWithZLoss
 from examples.llm.src.models.utils import (AutoTokenizerForMOD,
                                            convert_hf_causal_lm_to_prefix_lm,
+                                           add_bidirectional_mask_if_missing,
                                            init_empty_weights)
 
 __all__ = ['ComposerHFPrefixLM']
@@ -120,19 +120,5 @@ class ComposerHFPrefixLM(HuggingFaceModelWithZLoss):
 
     def forward(self, batch):
         # Add bidirectional_mask if it is missing and can be constructed
-        if 'bidirectional_mask' not in batch:
-            if batch.get('mode', None) == 'icl_task':
-                batch['bidirectional_mask'] = batch['attention_mask'].clone()
-                for i, continuation_indices in enumerate(
-                        batch['continuation_indices']):
-                    batch['bidirectional_mask'][i, continuation_indices] = 0
-            elif ('labels' in batch) and ('attention_mask' in batch):
-                batch['bidirectional_mask'] = torch.logical_and(
-                    torch.eq(batch['attention_mask'], 1),
-                    torch.eq(batch['labels'], _HF_IGNORE_INDEX),
-                ).type_as(batch['attention_mask'])
-            else:
-                raise KeyError(
-                    'No bidirectional_mask in batch and not sure how to construct one.'
-                )
+        add_bidirectional_mask_if_missing(batch)
         return super().forward(batch)

--- a/examples/llm/src/models/hf/hf_prefix_lm.py
+++ b/examples/llm/src/models/hf/hf_prefix_lm.py
@@ -11,8 +11,8 @@ from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
 from examples.llm.src.models.hf.model_wrapper import HuggingFaceModelWithZLoss
 from examples.llm.src.models.utils import (AutoTokenizerForMOD,
-                                           convert_hf_causal_lm_to_prefix_lm,
                                            add_bidirectional_mask_if_missing,
+                                           convert_hf_causal_lm_to_prefix_lm,
                                            init_empty_weights)
 
 __all__ = ['ComposerHFPrefixLM']

--- a/examples/llm/src/models/layers/attention.py
+++ b/examples/llm/src/models/layers/attention.py
@@ -82,10 +82,16 @@ class TorchCausalAttention(nn.Module):
         batch_size,
         heads,
         seq_len,
+        prefix_mask=None,
         key_padding_mask=None,
         alibi=False,
         dtype=None,
     ):
+
+        if prefix_mask is not None:
+            raise NotImplementedError(
+                'This attention implementation does not support use of `prefix_lm`.'
+            )
 
         # select seq_len subset of attn mask
         attn_mask = attn_mask[..., :seq_len, :seq_len]
@@ -213,10 +219,16 @@ class FlashCausalAttention(nn.Module):
         batch_size,
         heads,
         seq_len,
+        prefix_mask=None,
         key_padding_mask=None,
         alibi=False,
         dtype=None,
     ):
+        if prefix_mask is not None:
+            raise NotImplementedError(
+                'This attention implementation does not support use of `prefix_lm`.'
+            )
+
         return attn_mask  # None
 
 
@@ -273,7 +285,7 @@ class TritonFlashAttention(nn.Module):
                 num_heads=cfg.n_heads,
                 bias=True,
                 batch_first=True,
-                causal=self.causal,
+                causal=self.causal,  # type: ignore
                 softmax_scale=cfg.get('softmax_scale'),
                 device=device,
             )
@@ -364,10 +376,16 @@ class TritonFlashCausalAttention(TritonFlashAttention):
         batch_size,
         heads,
         seq_len,
+        prefix_mask=None,
         key_padding_mask=None,
         alibi=False,
         dtype=None,
     ):
+        if prefix_mask is not None:
+            raise NotImplementedError(
+                'This attention implementation does not support use of `prefix_lm`.'
+            )
+
         if attn_mask is not None:
             # select seq_len subset of attn mask
             attn_mask = attn_mask[..., :seq_len, :seq_len]

--- a/examples/llm/src/models/layers/attention.py
+++ b/examples/llm/src/models/layers/attention.py
@@ -218,12 +218,16 @@ class FlashCausalAttention(nn.Module):
         return attn_mask  # None
 
 
-class TritonFlashCausalAttention(nn.Module):
+class TritonFlashAttention(nn.Module):
     """Multi-headed self attention using triton FlashAttn kernel.
 
-    This also includes bias for Alibi integration.
-    """
+    This also includes bias for Alibi integration or Prefix LM attention
+    (see :class:`TritonFlashPrefixAttention` for the latter).
 
+    Don't invoke this class directly! Use `TritonFlashCausalAttention`
+    or `TritonFlashPrefixAttention`.
+    """
+    causal = None
     def __init__(self, cfg: DictConfig, device: Optional[str] = None):
         super().__init__()
         try:
@@ -266,7 +270,7 @@ class TritonFlashCausalAttention(nn.Module):
                 num_heads=cfg.n_heads,
                 bias=True,
                 batch_first=True,
-                causal=True,
+                causal=self.causal,
                 softmax_scale=cfg.get('softmax_scale'),
                 device=device,
             )
@@ -299,7 +303,7 @@ class TritonFlashCausalAttention(nn.Module):
                 qkv,
                 key_padding_mask=key_padding_mask,
                 attn_mask=attn_mask,
-                is_causal=True,
+                is_causal=self.causal,
                 need_weights=False,
                 average_attn_weights=False)
 
@@ -310,13 +314,15 @@ class TritonFlashCausalAttention(nn.Module):
                              key_padding_mask=None,
                              attn_mask=attn_mask,
                              need_weights=False)
+        
+    @classmethod
+    def mask_shape(cls, n_heads, seq_len, alibi):
+        if cls.causal:
+            return (1, n_heads, 1, seq_len) if alibi else None
+        return (1, n_heads, seq_len, seq_len) if alibi else None
 
-    @staticmethod
-    def mask_shape(n_heads, seq_len, alibi):
-        return (1, n_heads, 1, seq_len) if alibi else None
-
-    @staticmethod
-    def attn_mask_(attn_mask, n_heads, seq_len, alibi=False, alibi_bias_max=8):
+    @classmethod
+    def attn_mask_(cls, attn_mask, n_heads, seq_len, alibi=False, alibi_bias_max=8):
         if attn_mask is not None:
             # in-place fill causal attn mask
             attn_mask.zero_()
@@ -326,13 +332,25 @@ class TritonFlashCausalAttention(nn.Module):
                 attn_mask.add_(
                     alibi_bias(n_heads,
                                seq_len,
-                               full=False,
+                               full=not cls.causal,
                                alibi_bias_max=alibi_bias_max,
                                device=device,
                                dtype=dtype))
 
         return attn_mask
+    
+    @staticmethod
+    def generate_attn_mask(*args, **kwargs):
+        # To be implemented by child classes
+        raise NotImplementedError
 
+class TritonFlashCausalAttention(TritonFlashAttention):
+    """Triton FlashAttn kernel for a Causal LM.
+
+    See parent class :class:`TritonFlashAttention` for details.
+    """
+    causal = True
+    
     @staticmethod
     def generate_attn_mask(
         attn_mask,
@@ -362,6 +380,52 @@ class TritonFlashCausalAttention(nn.Module):
                 kpm_fill_value)
 
         return attn_mask
+
+class TritonFlashPrefixAttention(TritonFlashAttention):
+    """Triton FlashAttn kernel for a Prefix LM.
+
+    See parent class :class:`TritonFlashAttention` for details.
+    """
+    causal = False
+        
+    @staticmethod
+    def generate_attn_mask(
+        attn_mask,
+        batch_size,
+        heads,
+        seq_len,
+        prefix_mask,
+        key_padding_mask=None,
+        alibi=False,
+        dtype=None,
+    ):
+        if attn_mask is not None:
+            # select seq_len subset of attn mask
+            attn_mask = attn_mask[..., :seq_len, :seq_len]
+
+        # Mix the causal max and the bidirectional mask to get the full
+        # allowable attention (i.e. full = not accounting for padding yet)
+        causal = torch.tril(
+            torch.ones((seq_len, seq_len), dtype=torch.uint8, device=prefix_mask.device)
+        ).view(1, 1, seq_len, seq_len)
+        prefix = prefix_mask.view(batch_size, 1, 1, seq_len)
+        can_attend = torch.logical_or(causal, prefix)
+
+        # Account for padding
+        if key_padding_mask is not None:
+            not_padding = key_padding_mask.view(batch_size, 1, 1, seq_len)
+            can_attend = torch.logical_and(can_attend, not_padding)
+        
+        if attn_mask is None:
+            return can_attend # [batch_size, 1, seq_len, seq_len]
+
+        kpm_fill_value = -1e4  # numerically stable -inf
+        attn_mask = torch.where(can_attend, attn_mask, kpm_fill_value)
+        
+        if dtype is not None:
+            attn_mask = attn_mask.to(dtype)
+
+        return attn_mask # [batch_size, 1, seq_len, seq_len]
 
 
 def _check_apply_key_padding_mask(key_padding_mask):

--- a/examples/llm/src/models/mosaic_gpt.py
+++ b/examples/llm/src/models/mosaic_gpt.py
@@ -158,24 +158,17 @@ class MosaicGPT(nn.Module):
                                             alibi_bias_max=self.alibi_bias_max)
             self._attn_mask_initialized = True
 
-        if self.is_prefix_lm:
-            if prefix_mask is None:
-                raise ValueError(
-                    'prefix_mask cannot be None when using prefix_lm')
-            return self.causal_attn_cls.generate_attn_mask(
-                self.attn_mask,
-                batch_size,
-                self.cfg.n_heads,
-                seq_len,
-                prefix_mask,
-                key_padding_mask=key_padding_mask,
-                alibi=self.alibi,
-                dtype=dtype)
+        if self.is_prefix_lm and (prefix_mask is None):
+            raise ValueError('prefix_mask cannot be None when using prefix_lm')
+        elif (not self.is_prefix_lm) and (prefix_mask is not None):
+            raise ValueError(
+                'prefix_mask should be None when not using prefix_lm')
         return self.causal_attn_cls.generate_attn_mask(
             self.attn_mask,
             batch_size,
             self.cfg.n_heads,
             seq_len,
+            prefix_mask,
             key_padding_mask=key_padding_mask,
             alibi=self.alibi,
             dtype=dtype)

--- a/examples/llm/src/models/utils/__init__.py
+++ b/examples/llm/src/models/utils/__init__.py
@@ -4,10 +4,12 @@
 from examples.llm.src.models.utils.adapt_tokenizer import (
     AutoTokenizerForMOD, adapt_tokenizer_for_denoising)
 from examples.llm.src.models.utils.hf_prefixlm_converter import \
-    convert_hf_causal_lm_to_prefix_lm
+    convert_hf_causal_lm_to_prefix_lm, add_bidirectional_mask_if_missing
 from examples.llm.src.models.utils.meta_init_context import init_empty_weights
 
 __all__ = [
     'AutoTokenizerForMOD', 'adapt_tokenizer_for_denoising',
-    'convert_hf_causal_lm_to_prefix_lm', 'init_empty_weights'
+    'convert_hf_causal_lm_to_prefix_lm', 
+    'add_bidirectional_mask_if_missing',
+    'init_empty_weights'
 ]

--- a/examples/llm/src/models/utils/__init__.py
+++ b/examples/llm/src/models/utils/__init__.py
@@ -3,13 +3,12 @@
 
 from examples.llm.src.models.utils.adapt_tokenizer import (
     AutoTokenizerForMOD, adapt_tokenizer_for_denoising)
-from examples.llm.src.models.utils.hf_prefixlm_converter import \
-    convert_hf_causal_lm_to_prefix_lm, add_bidirectional_mask_if_missing
+from examples.llm.src.models.utils.hf_prefixlm_converter import (
+    add_bidirectional_mask_if_missing, convert_hf_causal_lm_to_prefix_lm)
 from examples.llm.src.models.utils.meta_init_context import init_empty_weights
 
 __all__ = [
     'AutoTokenizerForMOD', 'adapt_tokenizer_for_denoising',
-    'convert_hf_causal_lm_to_prefix_lm', 
-    'add_bidirectional_mask_if_missing',
+    'convert_hf_causal_lm_to_prefix_lm', 'add_bidirectional_mask_if_missing',
     'init_empty_weights'
 ]

--- a/examples/llm/src/models/utils/hf_prefixlm_converter.py
+++ b/examples/llm/src/models/utils/hf_prefixlm_converter.py
@@ -868,8 +868,8 @@ def convert_hf_causal_lm_to_prefix_lm(
 
 
 def add_bidirectional_mask_if_missing(batch: Dict[str, Any]):
-    """Attempts to add bidirectional_mask to batch if missing
-    
+    """Attempts to add bidirectional_mask to batch if missing.
+
     Raises:
         KeyError if bidirectional_mask is missing and can't be inferred
     """

--- a/examples/llm/src/models/utils/hf_prefixlm_converter.py
+++ b/examples/llm/src/models/utils/hf_prefixlm_converter.py
@@ -865,3 +865,26 @@ def convert_hf_causal_lm_to_prefix_lm(
             f'Model does not belong to set of supported HF models:' +\
             f'\n{_SUPPORTED_HF_MODELS}'
         )
+
+
+def add_bidirectional_mask_if_missing(batch: Dict[str, Any]):
+    """Attempts to add bidirectional_mask to batch if missing
+    
+    Raises:
+        KeyError if bidirectional_mask is missing and can't be inferred
+    """
+    if 'bidirectional_mask' not in batch:
+        if batch.get('mode', None) == 'icl_task':
+            batch['bidirectional_mask'] = batch['attention_mask'].clone()
+            for i, continuation_indices in enumerate(
+                    batch['continuation_indices']):
+                batch['bidirectional_mask'][i, continuation_indices] = 0
+        elif ('labels' in batch) and ('attention_mask' in batch):
+            batch['bidirectional_mask'] = torch.logical_and(
+                torch.eq(batch['attention_mask'], 1),
+                torch.eq(batch['labels'], -100),
+            ).type_as(batch['attention_mask'])
+        else:
+            raise KeyError(
+                'No bidirectional_mask in batch and not sure how to construct one.'
+            )


### PR DESCRIPTION
This PR introduces support for a Prefix-LM version of MosaicGPT. 
It slightly refactors the triton FA implementation to add `TritonFlashPrefixAttention` and adds logic to handle a prefix-lm-specific input `prefix_mask` (which controls which portions of the token sequence use bidirectional (inside the prefix) or causal attention).
I'm also slightly refactoring some of the code to re-use a utility for inferring the value of the required `bidirectional_mask` batch input.