### PR TITLE
Upgrade transformers to `4.27.2`

### DIFF
--- a/examples/llm/requirements.txt
+++ b/examples/llm/requirements.txt
@@ -6,7 +6,7 @@ flash-attn==0.2.8
 mosaicml-cli>=0.2.32,<1
 # need a newer version of triton
 triton==2.0.0.dev20221202
-transformers==4.25.1
+transformers==4.27.2
 omegaconf==2.2.3
 wandb==0.13.6
 pytest>=7.2.1,<8

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ packaging>=21,<23
 omegaconf>=2.2.3,<3
 # these are just for common/
 datasets==2.10.1
-transformers==4.25.1
+transformers==4.27.2
 mosaicml-streaming==0.3.0
 pynvml<12
 slack-sdk<4


### PR DESCRIPTION
This upgrade enables the fast OPT tokenizer. Should not make a big difference at training time, but will at dataset generation time.

Leaving as a draft for now, will wait until Composer' next release closes some bugs related to 4.27+