### PR TITLE
Add torch 2.0 based tensor parallel support

### DIFF
--- a/examples/llm/src/models/mosaic_gpt/configuration_mosaic_gpt.py
+++ b/examples/llm/src/models/mosaic_gpt/configuration_mosaic_gpt.py
@@ -7,6 +7,8 @@ from typing import Optional, Tuple, Union
 
 from transformers import PretrainedConfig
 
+from examples.llm.src.models.utils import is_torch_2_or_higher
+
 
 class MosaicGPTConfig(PretrainedConfig):
     model_type = 'mosaic_gpt'
@@ -45,6 +47,7 @@ class MosaicGPTConfig(PretrainedConfig):
         embedding_fraction: float = 1.0,
         low_precision_layernorm: bool = False,
         use_cache: bool = True,
+        tensor_parallel_mlp: bool = False,
         **kwargs,
     ):
         """The MosaicGPT configuration class.
@@ -88,6 +91,7 @@ class MosaicGPTConfig(PretrainedConfig):
             embedding_fraction (float): The fraction to scale the gradients of the embedding layer by.
             low_precision_layernorm (bool): Whether to use low precision layer normalization.
             use_cache (bool): Whether or not the model should return the last key/values attentions
+            tensor_parallel_mlp (bool): Whether or not to tensor parallelize the MLPs
         """
         self.d_model = d_model
         self.n_heads = n_heads
@@ -121,6 +125,7 @@ class MosaicGPTConfig(PretrainedConfig):
         self.embedding_fraction = embedding_fraction
         self.low_precision_layernorm = low_precision_layernorm
         self.use_cache = use_cache
+        self.tensor_parallel_mlp = tensor_parallel_mlp
         if 'name' in kwargs:
             del kwargs['name']
         if 'loss_fn' in kwargs:
@@ -153,4 +158,8 @@ class MosaicGPTConfig(PretrainedConfig):
                       str) and self.logit_scale != 'inv_sqrt_d_model':
             raise ValueError(
                 f"{self.logit_scale=} is not recognized as an option; use numeric value or 'inv_sqrt_d_model'."
+            )
+        if not is_torch_2_or_higher() and self.tensor_parallel_mlp:
+            raise NotImplementedError(
+                'Tensor Parallel with torch version < 2.0.0 is not implemented. Please set tensor_parallel_mlp to false.'
             )

--- a/examples/llm/src/models/utils/__init__.py
+++ b/examples/llm/src/models/utils/__init__.py
@@ -6,6 +6,7 @@ from examples.llm.src.models.utils.adapt_tokenizer import (
 from examples.llm.src.models.utils.hf_prefixlm_converter import (
     add_bidirectional_mask_if_missing, convert_hf_causal_lm_to_prefix_lm)
 from examples.llm.src.models.utils.meta_init_context import init_empty_weights
+from examples.llm.src.models.utils.misc import is_torch_2_or_higher
 from examples.llm.src.models.utils.param_init_fns import (  # type: ignore
     MODEL_INIT_REGISTRY, generic_param_init_fn_)
 
@@ -13,5 +14,10 @@ __all__ = [
     'AutoTokenizerForMOD', 'adapt_tokenizer_for_denoising',
     'convert_hf_causal_lm_to_prefix_lm', 'init_empty_weights',
     'add_bidirectional_mask_if_missing', 'generic_param_init_fn_',
-    'MODEL_INIT_REGISTRY'
+    'MODEL_INIT_REGISTRY', 'is_torch_2_or_higher'
 ]
+
+if is_torch_2_or_higher():
+    from examples.llm.src.models.utils.tensor_parallel import \
+        PairwiseSequenceParallel
+    __all__ += ['PairwiseSequenceParallel']

--- a/examples/llm/src/models/utils/misc.py
+++ b/examples/llm/src/models/utils/misc.py
@@ -1,0 +1,10 @@
+# Copyright 2022 MosaicML Examples authors
+# SPDX-License-Identifier: Apache-2.0
+import torch
+from packaging import version
+
+
+def is_torch_2_or_higher():
+    if version.parse(torch.__version__) >= version.parse('2.0.0'):
+        return True
+    return False

--- a/examples/llm/src/models/utils/tensor_parallel.py
+++ b/examples/llm/src/models/utils/tensor_parallel.py
@@ -1,0 +1,120 @@
+# Copyright 2022 MosaicML Examples authors
+# SPDX-License-Identifier: Apache-2.0
+
+###
+# The code in this file is copied from torch/distributed/tensor/parallel/style.py and
+# torch/distributed/_tensor/redistribute.py. PairwiseSequenceParallel is not available in torch 2.0.0 release and
+# this copying makes it available for torch 2.0.0. We will remove this code once we move to newer release of torch.
+###
+from typing import List, Optional
+
+import torch
+import torch.distributed._tensor.redistribute as redist  # type: ignore
+from torch.distributed._tensor import DeviceMesh, DTensor  # type: ignore
+from torch.distributed._tensor.placement_types import (  # type: ignore
+    Placement, Replicate)
+from torch.distributed._tensor.redistribute import \
+    redistribute_dtensor  # type: ignore
+from torch.distributed.tensor.parallel import (ParallelStyle,
+                                               make_input_replicate_1d,
+                                               make_input_shard_1d,
+                                               make_output_shard_1d)
+from torch.distributed.tensor.parallel._utils import (  # type: ignore
+    _prepare_input_validate, _prepare_output_validate)
+
+
+def backward(ctx, grad_output: 'dtensor.DTensor'):  # type: ignore[override]
+    previous_placement = ctx.previous_placement
+    previous_device_mesh = ctx.previous_device_mesh
+    # When we run backward pass of redistribute (i.e. manual redistribute from
+    # user code instead of torch_dispatch), we scan first and see if we need
+    # to change the target placement for one special case:
+    #   replicate -> partial.
+    # In this case we keep the grad as replicate, this is because we don't
+    # want to convert the replicated gradients back to partial, although
+    # that's logically conform with the same layout, converting the gradients
+    # back to partial is acutally useless as you would have to do reduce later
+    # which would be more expensive than keeping it replicate! For this reason,
+    # we keep the replicate grad here.
+    # TODO: see if this make sense for all cases.
+    target_placements: List[Placement] = []
+    for current, target in zip(grad_output.placements, previous_placement):
+        if not current.is_partial() and target.is_partial():
+            # keep target placement to replicate instead of partial in this case
+            target_placements.append(Replicate())
+        else:
+            target_placements.append(target)
+
+    return (
+        redistribute_dtensor(grad_output, previous_device_mesh,
+                             target_placements),
+        None,
+        None,
+    )
+
+
+# Monkey-patch Redistribute.backward to have a fix for PairwiseSequenceParallel
+# See https://github.com/pytorch/pytorch/pull/94369/files
+redist.Redistribute.backward = backward
+
+
+class PairwiseSequenceParallel(ParallelStyle):
+    """PairwiseSequenceParallel concatenate colwise and rowwise styles as a.
+
+    fixed pair together with sequence parallel like what Megatron-LM Sequence
+    parallel (https://arxiv.org/pdf/2205.05198.pdf) is doing. We assume both
+    input and output need to be sharded DTensors.
+
+    .. warning::     PairwiseSequenceParallel only supports ``nn.Multihead
+    Attention``,     ``nn.Transformer`` or even-number-layer MLP for now.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(make_input_reshard_replicate,
+                         make_output_reshard_tensor)
+
+
+@_prepare_input_validate  # type: ignore[arg-type] # pyre-ignore[56]
+def make_input_reshard_replicate(
+    input: torch.Tensor,
+    device_mesh: DeviceMesh,
+) -> DTensor:
+    """To construct a Sharded DTensor from a tensor on different ranks and then.
+
+    convert to a replicate DTensor.
+
+    Args:
+        input (:class:`torch.Tensor`): The input tensor on each rank which consists of a global DTensor
+            sharded on dimension ``0`` over the 1-D :class:`DeviceMesh`
+            and then the sharded DTensor is converted to a replicate DTensor.
+        device_mesh (:class:`DeviceMesh`, optional): The 1-D device mesh where ``input`` will be sharded.
+            If :class:`DeviceMesh` is not 1-D, an exception will be thrown.
+            Default: ``None``
+    Returns:
+        A :class:`DTensor` sharded on dimension ``0`` over ``device_mesh``
+            and then converted to replicate.
+    """
+    return make_input_replicate_1d(  # type: ignore[call-arg]
+        make_input_shard_1d(input, device_mesh, dim=0),
+        device_mesh  # type: ignore[call-arg]
+    )
+
+
+@_prepare_output_validate  # type: ignore[arg-type] # pyre-ignore[56]
+def make_output_reshard_tensor(
+    output: DTensor,
+    device_mesh: Optional[DeviceMesh] = None,
+) -> torch.Tensor:
+    """Convert Output DTensor to a sharded DTensor and return the local tensor.
+
+    Args:
+        output (:class:`DTensor`): Output of module to be converted.
+        device_mesh (:class:`DeviceMesh`, optional): Object needed to shard the output and it needs to be a 1D ``device_mesh``
+            and we will throw exceptions if a non-1D ``device_mesh`` is passed in.
+            If no ``device_mesh`` is passed in, we will reuse the one from output.
+            Default: ``None``
+    Return:
+        A :class:`torch.Tensor` object converted from output DTensor.
+    """
+    return make_output_shard_1d(
+        output, device_mesh).to_local()  # type: ignore[call-arg, attr-defined]


### PR DESCRIPTION
Add torch2.0 based tensor parallel support. By default, tensor parallel for MLPs is off. 

It doesn't affect the code when using torch < 2.0.0. if model.tensor_parallel_mlp=true with torch < 2.0.0, the following error is printed out. 

`Tensor Parallel with torch version < 2.0.0 is not implemented. Please set tensor_parallel_mlp to false.` 

~~Will add runs with and without this with torch 2.0.~~
- [x] [wandb link](https://wandb.ai/mosaic-ml/daya-tensor-parallel/reports/Compare-TP-vs-No_TP--VmlldzozODg4ODE3) PairwiseParallel

Tensor parallel based on  PairwiseParallel  requires that inputs to the tensor parallel ranks be the same. There is another version of it called PairwiseSeqParallel that all gathers inputs for the tensor parallel ranks and somehow that is not part of the 2.0 release. ~~I plan to add it later.~~ Added PairwiseSeqParallel. 

Reasons to check this in:

1. This is 0 => 1 and we can build upon and improve it
2. Others can also debug the performance issues.