### PR TITLE
Add support for output hidden states (for contrastive decoding) and beam search with past

### DIFF
--- a/examples/llm/src/models/mosaic_gpt/mosaic_gpt.py
+++ b/examples/llm/src/models/mosaic_gpt/mosaic_gpt.py
@@ -301,7 +301,7 @@ class MosaicGPT(PreTrainedModel):
         all_hidden_states = () if output_hidden_states else None
         for b_idx, block in enumerate(self.transformer.blocks):  # type: ignore
             if output_hidden_states:
-                assert all_hidden_states is not None
+                assert all_hidden_states is not None  # pyright
                 all_hidden_states = all_hidden_states + (x,)
             past_key_value = past_key_values[
                 b_idx] if past_key_values is not None else None
@@ -385,6 +385,11 @@ class MosaicGPT(PreTrainedModel):
 
     @staticmethod
     def _reorder_cache(past_key_values, beam_idx):
+        """Used by HuggingFace generate when using beam search with kv-caching.
+
+        See https://github.com/huggingface/transformers/blob/3ec7a47664ebe40c40f4b722f6bb1cd30c3821ec/src/transformers/models/gpt2/modeling_gpt2.py#L1122-L1133
+        for an example in transformers.
+        """
         reordered_past = []
         for layer_past in past_key_values:
             reordered_past += [

--- a/examples/llm/src/models/mosaic_gpt/mosaic_gpt.py
+++ b/examples/llm/src/models/mosaic_gpt/mosaic_gpt.py
@@ -273,7 +273,7 @@ class MosaicGPT(PreTrainedModel):
             if attention_mask is not None:
                 # adjust the position indices to account for padding tokens
                 pos = torch.clamp(pos - torch.cumsum(
-                    (attention_mask == 0)[:, past_position:], dim=1),
+                    (attention_mask == 0), dim=1)[:, past_position:],
                                   min=0)
 
             pos_emb = self.transformer.wpe(pos)  # type: ignore

--- a/examples/llm/src/models/mosaic_gpt/mosaic_gpt.py
+++ b/examples/llm/src/models/mosaic_gpt/mosaic_gpt.py
@@ -387,9 +387,11 @@ class MosaicGPT(PreTrainedModel):
     def _reorder_cache(past_key_values, beam_idx):
         reordered_past = []
         for layer_past in past_key_values:
-            reordered_past += (tuple(
-                past_state.index_select(0, beam_idx)
-                for past_state in layer_past),)
+            reordered_past += [
+                tuple(
+                    past_state.index_select(0, beam_idx)
+                    for past_state in layer_past)
+            ]
         return reordered_past
 
 

--- a/examples/llm/src/models/mosaic_gpt/mosaic_gpt.py
+++ b/examples/llm/src/models/mosaic_gpt/mosaic_gpt.py
@@ -302,6 +302,7 @@ class MosaicGPT(PreTrainedModel):
         all_hidden_states = () if output_hidden_states else None
         for b_idx, block in enumerate(self.transformer.blocks):  # type: ignore
             if output_hidden_states:
+                assert all_hidden_states is not None
                 all_hidden_states = all_hidden_states + (x,)
             past_key_value = past_key_values[
                 b_idx] if past_key_values is not None else None

--- a/examples/llm/src/models/mosaic_gpt/mosaic_gpt.py
+++ b/examples/llm/src/models/mosaic_gpt/mosaic_gpt.py
@@ -228,9 +228,6 @@ class MosaicGPT(PreTrainedModel):
         if output_attentions:
             raise NotImplementedError(
                 'output_attentions is not implemented yet for MosaicGPT')
-        if output_hidden_states:
-            raise NotImplementedError(
-                'output_hidden_states is not implemented yet for MosaicGPT')
 
         if attention_mask is not None and attention_mask[:, 0].sum(
         ) != attention_mask.shape[0] and self.training:
@@ -302,7 +299,10 @@ class MosaicGPT(PreTrainedModel):
             past_key_values = [() for _ in range(self.config.n_layers)
                               ]  # type: ignore
 
+        all_hidden_states = () if output_hidden_states else None
         for b_idx, block in enumerate(self.transformer.blocks):  # type: ignore
+            if output_hidden_states:
+                all_hidden_states = all_hidden_states + (x,)
             past_key_value = past_key_values[
                 b_idx] if past_key_values is not None else None
             x, past_key_value = block(x,
@@ -328,7 +328,8 @@ class MosaicGPT(PreTrainedModel):
             logits *= self.logit_scale
 
         return CausalLMOutputWithPast(logits=logits,
-                                      past_key_values=past_key_values)
+                                      past_key_values=past_key_values,
+                                      hidden_states=all_hidden_states)
 
     # Param Initialization, needed for device='meta' fast initialization
     def param_init_fn(self, module):
@@ -381,6 +382,15 @@ class MosaicGPT(PreTrainedModel):
             'past_key_values': past_key_values,
             'use_cache': kwargs.get('use_cache'),
         }
+
+    @staticmethod
+    def _reorder_cache(past_key_values, beam_idx):
+        reordered_past = []
+        for layer_past in past_key_values:
+            reordered_past += (tuple(
+                past_state.index_select(0, beam_idx)
+                for past_state in layer_past),)
+        return reordered_past
 
 
 class ComposerMosaicGPT(HuggingFaceModel):

--- a/examples/llm/tests/test_model.py
+++ b/examples/llm/tests/test_model.py
@@ -808,3 +808,38 @@ def test_generate_with_past_kv():
         assert len(kwargs['past_key_values']) == hf_config.n_layers
         assert kwargs['past_key_values'][0][0].shape == (1, 3,
                                                          hf_config.d_model)
+
+
+@pytest.mark.parametrize('generation_kwargs', [{
+    'max_new_tokens': 2,
+    'num_beams': 4
+}, {
+    'max_new_tokens': 2,
+    'top_k': 5,
+    'penalty_alpha': 0.4
+}, {
+    'do_sample': True,
+    'top_p': 0.95
+}])
+def test_generation_kwargs_dont_crash(generation_kwargs):
+    hf_config = MosaicGPTConfig(
+        init_device='cpu',
+        d_model=128,
+        n_heads=4,
+        n_layers=2,
+        mlp_ratio=2,
+        max_seq_len=2048,
+        emb_pdrop=0.1,
+        resid_pdrop=0.2,
+        attn_impl='torch',
+    )
+    mosaic_gpt = MosaicGPT(hf_config)
+    mosaic_gpt.eval()
+
+    # no padding in the input
+    no_padding_input_ids = torch.tensor([[11274, 16390, 11]])
+    no_padding_attention_mask = torch.tensor([[1, 1, 1]])
+
+    _ = mosaic_gpt.generate(input_ids=no_padding_input_ids,
+                            attention_mask=no_padding_attention_mask,
+                            **generation_kwargs)


### PR DESCRIPTION
This PR adds support for `output_hidden_states` (which enables contrastive decoding), and `_reorder_cache` function (which enables using beam search with past).