### PR TITLE
Fix slicing for padding + cache

### DIFF
--- a/examples/llm/src/models/mosaic_gpt/mosaic_gpt.py
+++ b/examples/llm/src/models/mosaic_gpt/mosaic_gpt.py
@@ -278,7 +278,6 @@ class MosaicGPT(PreTrainedModel):
                     (attention_mask == 0), dim=1)[:, past_position:],
                                   min=0)
 
-            print(pos)
             pos_emb = self.transformer.wpe(pos)  # type: ignore
             x = tok_emb + pos_emb
 

--- a/examples/llm/src/models/mosaic_gpt/mosaic_gpt.py
+++ b/examples/llm/src/models/mosaic_gpt/mosaic_gpt.py
@@ -272,13 +272,13 @@ class MosaicGPT(PreTrainedModel):
                                S + past_position,
                                dtype=torch.long,
                                device=input_ids.device).unsqueeze(0)
-
             if attention_mask is not None:
                 # adjust the position indices to account for padding tokens
                 pos = torch.clamp(pos - torch.cumsum(
-                    (attention_mask == 0)[:, past_position:], dim=1),
+                    (attention_mask == 0), dim=1)[:, past_position:],
                                   min=0)
 
+            print(pos)
             pos_emb = self.transformer.wpe(pos)  # type: ignore
             x = tok_emb + pos_emb
 

--- a/examples/llm/tests/test_model.py
+++ b/examples/llm/tests/test_model.py
@@ -686,6 +686,62 @@ def test_save_from_pretrained(tmp_path):
     check_hf_model_equivalence(mosaic_gpt, mosaic_gpt2)
 
 
+def test_forward_with_cache_and_padding():
+    hf_config = MosaicGPTConfig(
+        init_device='cpu',
+        d_model=128,
+        n_heads=4,
+        n_layers=2,
+        mlp_ratio=2,
+        max_seq_len=2048,
+        emb_pdrop=0.1,
+        resid_pdrop=0.2,
+        attn_impl='torch',
+    )
+
+    mosaic_gpt = MosaicGPT(hf_config)
+    mosaic_gpt.eval()
+
+    first_input_ids_no_padding = torch.tensor([[11274, 16390, 11]])
+    first_attention_mask_no_padding = torch.tensor([[1, 1, 1]]).bool()
+
+    # start with passing the first three tokens through
+    first_output_no_padding = mosaic_gpt(
+        first_input_ids_no_padding,
+        attention_mask=first_attention_mask_no_padding)
+
+    second_input_ids_no_padding = torch.tensor([[11274, 16390, 11, 11274]])
+    second_attention_mask_no_padding = torch.tensor([[1, 1, 1, 1]]).bool()
+
+    # pass through the fourth token by itself, using the key-value cache
+    second_output_no_padding = mosaic_gpt(
+        second_input_ids_no_padding[:, -1].unsqueeze(-1),
+        attention_mask=second_attention_mask_no_padding,
+        past_key_values=first_output_no_padding.past_key_values)
+
+    first_input_ids_padding = torch.tensor([[50256, 11274, 16390, 11]])
+    first_attention_mask_padding = torch.tensor([[0, 1, 1, 1]]).bool()
+
+    # start with passing the first three tokens through
+    first_output_padding = mosaic_gpt(
+        first_input_ids_padding, attention_mask=first_attention_mask_padding)
+
+    second_input_ids_padding = torch.tensor([[50256, 11274, 16390, 11, 11274]])
+    second_attention_mask_padding = torch.tensor([[0, 1, 1, 1, 1]]).bool()
+
+    # pass through the fourth token by itself, using the key-value cache
+    second_output_padding = mosaic_gpt(
+        second_input_ids_padding[:, -1].unsqueeze(-1),
+        attention_mask=second_attention_mask_padding,
+        past_key_values=first_output_padding.past_key_values)
+
+    torch.testing.assert_close(second_output_no_padding.logits,
+                               second_output_padding.logits[:,
+                                                            -1, :].unsqueeze(1),
+                               atol=1e-8,
+                               rtol=1e-8)
+
+
 @pytest.mark.parametrize('attention_impl,device', [('torch', 'cpu'),
                                                    ('flash', 'gpu'),
                                                    ('triton', 'gpu'),

--- a/examples/llm/tests/test_model.py
+++ b/examples/llm/tests/test_model.py
@@ -740,8 +740,8 @@ def test_forward_with_cache_and_padding():
     torch.testing.assert_close(second_output_no_padding.logits,
                                second_output_padding.logits[:,
                                                             -1, :].unsqueeze(1),
-                               atol=1e-8,
-                               rtol=1e-8)
+                               atol=1e-6,
+                               rtol=1e-6)
 
 
 @pytest.mark.parametrize('attention_impl,device', [('torch', 'cpu'),


### PR DESCRIPTION
Fixes a bug in the position id adjustment when using kv caching and padding together. Previously, the slicing happened to the `attention_mask == 0` part, but should have happened outside of the `cumsum` part. This only had an effect when doing both kv caching and padding together, so definitely should not affect training, only generation.