### PR TITLE
fix model_max_length setting

### DIFF
--- a/examples/llm/src/models/mosaic_gpt/mosaic_gpt.py
+++ b/examples/llm/src/models/mosaic_gpt/mosaic_gpt.py
@@ -417,6 +417,12 @@ class ComposerMosaicGPT(HuggingFaceModel):
         tokenizer = AutoTokenizer.from_pretrained(tokenizer_name,
                                                   **tokenizer_kwargs)
 
+        # HuggingFace does not respect the model_max_length kwarg, and overrides it with
+        # min(kwargs['model_max_length'], original_config['model_max_length']), so we explicitly
+        # set it here
+        if 'model_max_length' in tokenizer_kwargs:
+            tokenizer.model_max_length = tokenizer_kwargs['model_max_length']
+
         train_metrics = [
             LanguageCrossEntropy(hf_config.vocab_size),
             LanguagePerplexity(hf_config.vocab_size)

--- a/examples/llm/tests/test_model.py
+++ b/examples/llm/tests/test_model.py
@@ -19,6 +19,7 @@ from transformers.modeling_outputs import CausalLMOutputWithPast
 
 from examples.llm import (COMPOSER_MODEL_REGISTRY, ComposerHFCausalLM,
                           ComposerHFPrefixLM)
+from examples.llm.src.models.layers import attention
 from examples.llm.src.models.mosaic_gpt import MosaicGPT, MosaicGPTConfig
 
 
@@ -901,3 +902,17 @@ def test_generation_kwargs_dont_crash(generation_kwargs):
     _ = mosaic_gpt.generate(input_ids=no_padding_input_ids,
                             attention_mask=no_padding_attention_mask,
                             **generation_kwargs)
+
+
+def test_tokenizer_max_length_load():
+    conf_path = 'yamls/mosaic_gpt/testing.yaml'
+    with open(conf_path) as f:
+        test_cfg = om.load(f)
+
+    test_cfg.max_seq_len = 2048
+    test_cfg.model.alibi = True
+    test_cfg.model.attn_impl = 'torch'
+
+    model = COMPOSER_MODEL_REGISTRY[test_cfg.model.name](test_cfg.model,
+                                                         test_cfg.tokenizer)
+    assert model.tokenizer.model_max_length == 2048

--- a/examples/llm/tests/test_model.py
+++ b/examples/llm/tests/test_model.py
@@ -910,8 +910,6 @@ def test_tokenizer_max_length_load():
         test_cfg = om.load(f)
 
     test_cfg.max_seq_len = 2048
-    test_cfg.model.alibi = True
-    test_cfg.model.attn_impl = 'torch'
 
     model = COMPOSER_MODEL_REGISTRY[test_cfg.model.name](test_cfg.model,
                                                          test_cfg.tokenizer)

--- a/examples/llm/tests/test_model.py
+++ b/examples/llm/tests/test_model.py
@@ -19,7 +19,6 @@ from transformers.modeling_outputs import CausalLMOutputWithPast
 
 from examples.llm import (COMPOSER_MODEL_REGISTRY, ComposerHFCausalLM,
                           ComposerHFPrefixLM)
-from examples.llm.src.models.layers import attention
 from examples.llm.src.models.mosaic_gpt import MosaicGPT, MosaicGPTConfig
 
 

--- a/examples/llm/tests/test_model.py
+++ b/examples/llm/tests/test_model.py
@@ -903,13 +903,13 @@ def test_generation_kwargs_dont_crash(generation_kwargs):
                             **generation_kwargs)
 
 
-def test_tokenizer_max_length_load():
+def test_tokenizer_max_length_load(max_seq_len=2048):
     conf_path = 'yamls/mosaic_gpt/testing.yaml'
     with open(conf_path) as f:
         test_cfg = om.load(f)
 
-    test_cfg.max_seq_len = 2048
+    test_cfg.max_seq_len = max_seq_len
 
     model = COMPOSER_MODEL_REGISTRY[test_cfg.model.name](test_cfg.model,
                                                          test_cfg.tokenizer)
-    assert model.tokenizer.model_max_length == 2048
+    assert model.tokenizer.model_max_length == max_seq_len

--- a/examples/llm/tests/test_tokenizer.py
+++ b/examples/llm/tests/test_tokenizer.py
@@ -27,6 +27,10 @@ def test_load_tokenizer():
     assert tokenizer.vocab_size == 50257
     assert tokenizer.name_or_path == 'gpt2'
 
+    # HuggingFace overrides model_max_length, so this check would fail. We explicitly reset the
+    # model_max_length in ComposerMosaicGPT
+    # assert tokenizer.model_max_length == resolved_om_tokenizer_config['kwargs']['model_max_length']
+
     in_str = 'hello\n\nhello'
     out_token_key = [31373, 198, 198, 31373]
 


### PR DESCRIPTION
This PR fixes the setting of `tokenizer.model_max_length`, because huggingface overrides the provided kwarg with the min of the kwarg and the original config value (https://github.com/huggingface/transformers/blob/68287689f2f0d8b7063c400230b3766987abf18d/src/transformers/tokenization_utils_base.py#L1929-L1943).

wandb proving that the yaml that failed before (alibi + icl) now works: https://wandb.ai/mosaic-ml/daniel-debug/runs/3dnh4zwl?workspace=user-danielking