### PR TITLE
updt flg

### DIFF
--- a/examples/llm/src/models/mosaic_gpt/configuration_mosaic_gpt.py
+++ b/examples/llm/src/models/mosaic_gpt/configuration_mosaic_gpt.py
@@ -44,7 +44,7 @@ class MosaicGPTConfig(PretrainedConfig):
         init_nonlinearity: str = 'leaky_relu',
         embedding_fraction: float = 1.0,
         low_precision_layernorm: bool = False,
-        use_cache: bool = True,
+        use_cache: bool = False,
         **kwargs,
     ):
         """The MosaicGPT configuration class.

--- a/examples/llm/tests/test_model.py
+++ b/examples/llm/tests/test_model.py
@@ -714,6 +714,7 @@ def test_forward_with_cache_and_padding(alibi):
         resid_pdrop=0.2,
         attn_impl='torch',
         alibi=alibi,
+        use_cache=True,
     )
 
     mosaic_gpt = MosaicGPT(hf_config)
@@ -788,6 +789,7 @@ def test_forward_with_cache(attention_impl, device, alibi):
         resid_pdrop=0.2,
         attn_impl=attention_impl,
         alibi=alibi,
+        use_cache=True,
     )
     reproducibility.seed_all(1234)
     mosaic_gpt = MosaicGPT(hf_config)
@@ -861,6 +863,7 @@ def test_generate_with_past_kv(alibi):
         resid_pdrop=0.2,
         attn_impl='torch',
         alibi=alibi,
+        use_cache=True,
     )
     mosaic_gpt = MosaicGPT(hf_config)
     mosaic_gpt.eval()
@@ -914,6 +917,7 @@ def test_generation_kwargs_dont_crash(generation_kwargs, alibi):
         resid_pdrop=0.2,
         attn_impl='torch',
         alibi=alibi,
+        use_cache=True,
     )
     mosaic_gpt = MosaicGPT(hf_config)
     mosaic_gpt.eval()


### PR DESCRIPTION
Fixes a memory issue with large models.
Previously we got OOM when running larger models.
Now we have 48.9% MFU for running 30B model on 128 GPUs at micro_batch_size=8

```
[batch=17/30]:
         Train trainer/global_step: 16
         Train trainer/batch_idx: 16
         Train memory/allocated_mem: 5.3984
         Train memory/active_mem: 5.3984
         Train memory/inactive_mem: 1.6375
         Train memory/reserved_mem: 35.9910
         Train memory/alloc_retries: 4
         Train trainer/device_train_microbatch_size: 8
         Train loss/train/total: 11.8630
         Train metrics/train/LanguageCrossEntropy: 11.8632
         Train metrics/train/LanguagePerplexity: 141947.9219
         Train lr-DecoupledAdamW/group0: 0.0000
         Train throughput/batches_per_sec: 0.0247
         Train throughput/samples_per_sec: 50.6453
         Train throughput/device/batches_per_sec: 0.0002
         Train throughput/device/samples_per_sec: 0.3957
         Train throughput/tokens_per_sec: 103721.5395
         Train throughput/device/tokens_per_sec: 810.3245
         Train throughput/flops_per_sec: 19531489960084512.0000
         Train throughput/device/flops_per_sec: 152589765313160.2500
         Train throughput/device/mfu: 0.4891
         Train wall_clock/train: 0.2010
         Train wall_clock/val: 0.0000
         Train wall_clock/total: 0.2010
```