### PR TITLE
Support only-within-sequence attention for MosaicGPT

### DIFF
--- a/examples/llm/__init__.py
+++ b/examples/llm/__init__.py
@@ -4,8 +4,7 @@
 try:
     import torch
 
-    from examples.llm.inference.inference import (MosaicGPTInference,
-                                                  get_mosaicgpt_inference_model)
+    from examples.llm.inference.inference import get_mosaicgpt_inference_model
     from examples.llm.src.model_registry import COMPOSER_MODEL_REGISTRY
     from examples.llm.src.models.hf import (ComposerHFCausalLM,
                                             ComposerHFPrefixLM, ComposerHFT5)
@@ -42,6 +41,5 @@ __all__ = [
     'GPTBlock',
     'MosaicGPT',
     'ComposerMosaicGPT',
-    'MosaicGPTInference',
     'get_mosaicgpt_inference_model',
 ]

--- a/examples/llm/inference/__init__.py
+++ b/examples/llm/inference/__init__.py
@@ -1,10 +1,8 @@
 # Copyright 2022 MosaicML Examples authors
 # SPDX-License-Identifier: Apache-2.0
 
-from examples.llm.inference.inference import (MosaicGPTInference,
-                                              get_mosaicgpt_inference_model)
+from examples.llm.inference.inference import get_mosaicgpt_inference_model
 
 __all__ = [
-    'MosaicGPTInference',
     'get_mosaicgpt_inference_model',
 ]

--- a/examples/llm/inference/inference.py
+++ b/examples/llm/inference/inference.py
@@ -1,87 +1,14 @@
 # Copyright 2022 MosaicML Examples authors
 # SPDX-License-Identifier: Apache-2.0
+import sys
 import warnings
-from typing import List
 
 import torch
 from composer.core import get_precision_context
+from composer.utils import get_device
 from omegaconf import OmegaConf as om
 
 from examples.llm.src import COMPOSER_MODEL_REGISTRY
-
-
-def sample_top_p(probs, p):
-    probs_sort, probs_idx = torch.sort(probs, dim=-1, descending=True)
-    probs_sum = torch.cumsum(probs_sort, dim=-1)
-    mask = probs_sum - probs_sort > p
-    probs_sort[mask] = 0.0
-    probs_sort.div_(probs_sort.sum(dim=-1, keepdim=True))
-    next_token = torch.multinomial(probs_sort, num_samples=1)
-    next_token = torch.gather(probs_idx, -1, next_token)
-    return next_token
-
-
-class MosaicGPTInference:
-
-    def __init__(self, cfg, model, tokenizer):
-        self.cfg = cfg
-        self.model = model
-        self.tokenizer = tokenizer
-
-    def generate(
-        self,
-        prompts: List[str],
-        max_gen_len: int,
-        temperature: float = 0.8,
-        top_p: float = 0.95,
-    ) -> List[str]:
-        if isinstance(prompts, str):
-            prompts = [prompts]
-
-        bsz = len(prompts)
-
-        prompt_tokens = [self.tokenizer.encode(x) for x in prompts]
-
-        min_prompt_size = min([len(t) for t in prompt_tokens])
-        max_prompt_size = max([len(t) for t in prompt_tokens])
-
-        total_len = min(self.cfg.max_seq_len, max_gen_len + max_prompt_size)
-
-        tokens = torch.full((bsz, total_len), -100).cuda().long()
-        for k, t in enumerate(prompt_tokens):
-            tokens[k, :len(t)] = torch.tensor(t).long()
-        input_text_mask = tokens != -100
-        start_pos = min_prompt_size
-        for cur_pos in range(start_pos, total_len):
-            with torch.no_grad():
-                with get_precision_context(self.cfg.get('precision',
-                                                        'amp_bf16')):
-                    logits = self.model.forward(
-                        {'input_ids': tokens[:, :cur_pos]})
-            logits = logits[:, -1, :]
-            logits = logits.float()
-            if temperature > 0:
-                probs = torch.softmax(logits / temperature, dim=-1)
-                next_token = sample_top_p(probs, top_p)
-            else:
-                next_token = torch.argmax(logits, dim=-1)
-            next_token = next_token.reshape(-1)
-            # only replace token if prompt has already been generated
-            next_token = torch.where(input_text_mask[:, cur_pos],
-                                     tokens[:, cur_pos], next_token)
-            tokens[:, cur_pos] = next_token
-
-        decoded = []
-        for i, t in enumerate(tokens.tolist()):
-            # cut to max gen len
-            t = t[:len(prompt_tokens[i]) + max_gen_len]
-            # cut to eos tok if any
-            try:
-                t = t[:t.index(self.tokenizer.eos_token_id)]
-            except ValueError:
-                pass
-            decoded.append(self.tokenizer.decode(t))
-        return decoded
 
 
 def build_composer_model(model_cfg, tokenizer_cfg):
@@ -95,7 +22,7 @@ def build_composer_model(model_cfg, tokenizer_cfg):
             f'Not sure how to build model with name={model_cfg.name}')
 
 
-def get_mosaicgpt_inference_model(checkpoint_yaml_path: str, tokenizer):
+def get_mosaicgpt_inference_model(checkpoint_yaml_path: str):
     with open(checkpoint_yaml_path) as f:
         cfg = om.load(f)
     # set init_device to cpu for checkpoint loading
@@ -109,11 +36,61 @@ def get_mosaicgpt_inference_model(checkpoint_yaml_path: str, tokenizer):
 
     checkpoint = torch.load(ckpt_load_path, map_location='cpu')
 
-    model.load_state_dict(checkpoint['state']['model'], strict=True)
+    if 'state' in checkpoint.keys():
+        # it's a full training checkpoint
+        model.load_state_dict(checkpoint['state']['model'], strict=True)
+    else:
+        # it's a weights-only checkpoint
+        model.load_state_dict(checkpoint, strict=True)
 
-    model.cuda()
+    if model.tokenizer.pad_token_id is None:
+        warnings.warn(
+            'pad_token_id is not set for the tokenizer. Using eos_token_id as pad_token_id.'
+        )
+        model.tokenizer.pad_token_id = model.tokenizer.eos_token_id
+    model.tokenizer.padding_side = 'left'
+
+    return model
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print('please provide a configuration yaml')
+        sys.exit(-1)
+    yaml_path = sys.argv[1]
+    with open(yaml_path) as f:
+        cfg = om.load(f)
+    model = get_mosaicgpt_inference_model(yaml_path)
     model.eval()
 
-    generator = MosaicGPTInference(cfg, model, tokenizer)
+    generate_kwargs = {
+        'max_new_tokens': 100,
+        'use_cache': True,
+        'do_sample': True,
+        'top_p': 0.95,
+        'eos_token_id': model.tokenizer.eos_token_id,
+    }
+    prompts = [
+        'My name is',
+        'This is an explanation of deep learning to a five year old. Deep learning is',
+    ]
+    device = get_device(None)
+    device.module_to_device(model)
+    encoded_inp = model.tokenizer(prompts, return_tensors='pt', padding=True)
+    for key, value in encoded_inp.items():
+        encoded_inp[key] = device.tensor_to_device(value)
 
-    return generator
+    with torch.no_grad():
+        with get_precision_context(
+                cfg.get(
+                    'precision',  # type: ignore
+                    'amp_bf16')):
+            generation = model.model.generate(
+                input_ids=encoded_inp['input_ids'],
+                attention_mask=encoded_inp['attention_mask'],
+                **generate_kwargs,
+            )
+
+    decoded_out = model.tokenizer.batch_decode(generation,
+                                               skip_special_tokens=True)
+    print('\n###\n'.join(decoded_out))

--- a/examples/llm/src/models/layers/attention.py
+++ b/examples/llm/src/models/layers/attention.py
@@ -203,9 +203,9 @@ def triton_flash_attn_fn(
 
     if key_padding_mask is not None:
         warnings.warn(
-            'Propogating key_padding_mask to the attention module ' +\
+            'Propagating key_padding_mask to the attention module ' +\
             'and applying it within the attention module can cause ' +\
-            'unneccessary computation/memory usage. Consider integrating ' +\
+            'unnecessary computation/memory usage. Consider integrating ' +\
             'into attn_bias once and passing that to each attention ' +\
             'module instead.'
         )
@@ -346,15 +346,16 @@ class MultiheadAttention(nn.Module):
         return self.out_proj(context), attn_weights, past_key_value
 
 
-def attn_bias_shape(attn_impl, n_heads, seq_len, alibi, prefix_lm, causal):
+def attn_bias_shape(attn_impl, n_heads, seq_len, alibi, prefix_lm, causal,
+                    use_sequence_id):
     if attn_impl == 'flash':
         return None
     elif attn_impl in ['torch', 'triton']:
         if alibi:
-            if prefix_lm or not causal:
+            if (prefix_lm or not causal) or use_sequence_id:
                 return (1, n_heads, seq_len, seq_len)
             return (1, n_heads, 1, seq_len)
-        elif prefix_lm:
+        elif prefix_lm or use_sequence_id:
             return (1, 1, seq_len, seq_len)
         return None
     else:

--- a/examples/llm/src/models/mosaic_gpt/configuration_mosaic_gpt.py
+++ b/examples/llm/src/models/mosaic_gpt/configuration_mosaic_gpt.py
@@ -44,7 +44,7 @@ class MosaicGPTConfig(PretrainedConfig):
         init_nonlinearity: str = 'leaky_relu',
         embedding_fraction: float = 1.0,
         low_precision_layernorm: bool = False,
-        use_cache: bool = True,
+        use_cache: bool = False,
         **kwargs,
     ):
         """The MosaicGPT configuration class.

--- a/examples/llm/src/models/mosaic_gpt/configuration_mosaic_gpt.py
+++ b/examples/llm/src/models/mosaic_gpt/configuration_mosaic_gpt.py
@@ -72,8 +72,9 @@ class MosaicGPTConfig(PretrainedConfig):
                 extra `prefix_mask` argument which indicates which tokens belong to the prefix. Tokens in the prefix
                 can attend to one another bi-directionally. Tokens outside the prefix use causal attention.
             attn_uses_sequence_id (Optional[bool]): Whether to restrict attention to tokens that have the same sequence_id.
-                This requires passing an extra `sequence_id` argument which indicates which sub-sequence each token belongs
-                to. Defaults to ``False`` meaning any provided `sequence_id` will be ignored.
+                When the model is in `train` mode, this requires passing an extra `sequence_id` argument which indicates
+                which sub-sequence each token belongs to.
+                Defaults to ``False`` meaning any provided `sequence_id` will be ignored.
             alibi (bool): Whether to use the alibi bias instead of position embeddings.
             alibi_bias_max (int): The maximum value of the alibi bias.
             init_device (str): The device to use for parameter initialization.

--- a/examples/llm/src/models/mosaic_gpt/configuration_mosaic_gpt.py
+++ b/examples/llm/src/models/mosaic_gpt/configuration_mosaic_gpt.py
@@ -28,6 +28,7 @@ class MosaicGPTConfig(PretrainedConfig):
         attn_clip_qkv: Optional[float] = None,
         softmax_scale: Optional[float] = None,
         prefix_lm: Optional[bool] = False,
+        attn_uses_sequence_id: Optional[bool] = False,
         alibi: bool = False,
         alibi_bias_max: int = 8,
         init_device: str = 'cpu',
@@ -70,6 +71,9 @@ class MosaicGPTConfig(PretrainedConfig):
             prefix_lm (Optional[bool]): Whether the model should operate as a Prefix LM. This requires passing an
                 extra `prefix_mask` argument which indicates which tokens belong to the prefix. Tokens in the prefix
                 can attend to one another bi-directionally. Tokens outside the prefix use causal attention.
+            attn_uses_sequence_id (Optional[bool]): Whether to restrict attention to tokens that have the same sequence_id.
+                This requires passing an extra `sequence_id` argument which indicates which sub-sequence each token belongs
+                to. Defaults to ``False`` meaning any provided `sequence_id` will be ignored.
             alibi (bool): Whether to use the alibi bias instead of position embeddings.
             alibi_bias_max (int): The maximum value of the alibi bias.
             init_device (str): The device to use for parameter initialization.
@@ -104,6 +108,7 @@ class MosaicGPTConfig(PretrainedConfig):
         self.attn_clip_qkv = attn_clip_qkv
         self.softmax_scale = softmax_scale
         self.prefix_lm = prefix_lm
+        self.attn_uses_sequence_id = attn_uses_sequence_id
         self.alibi = alibi
         self.alibi_bias_max = alibi_bias_max
         self.init_device = init_device
@@ -145,6 +150,12 @@ class MosaicGPTConfig(PretrainedConfig):
         if self.alibi and self.attn_impl not in ['torch', 'triton']:
             raise NotImplementedError(
                 'alibi only implemented with torch and triton attention.')
+        if self.attn_uses_sequence_id and self.attn_impl not in [
+                'torch', 'triton'
+        ]:
+            raise NotImplementedError(
+                'attn_uses_sequence_id only implemented with torch and triton attention.'
+            )
         if self.embedding_fraction > 1 or self.embedding_fraction <= 0:
             raise ValueError(
                 'model.embedding_fraction must be between 0 (exclusive) and 1 (inclusive)!'

--- a/examples/llm/src/models/mosaic_gpt/mosaic_gpt.py
+++ b/examples/llm/src/models/mosaic_gpt/mosaic_gpt.py
@@ -279,7 +279,8 @@ class MosaicGPT(PreTrainedModel):
                     'sequence_id is a required argument when MosaicGPT is configured with attn_uses_sequence_id=True ' +\
                     'and the model is in train mode.'
                 )
-            elif sequence_id is not None:
+            elif (self.attn_uses_sequence_id is False) and (sequence_id
+                                                            is not None):
                 warnings.warn(
                     'MosaicGPT received non-None input for `sequence_id` but is configured with attn_uses_sequence_id=False. ' +\
                     'This input will be ignored. If you want the model to use `sequence_id`, set attn_uses_sequence_id to True.'

--- a/examples/llm/src/models/mosaic_gpt/mosaic_gpt.py
+++ b/examples/llm/src/models/mosaic_gpt/mosaic_gpt.py
@@ -273,7 +273,7 @@ class MosaicGPT(PreTrainedModel):
                 'prefix_mask is a required argument when MosaicGPT is configured with prefix_lm=True.'
             )
 
-        if self.training():
+        if self.training:
             if self.attn_uses_sequence_id and sequence_id is None:
                 raise ValueError(
                     'sequence_id is a required argument when MosaicGPT is configured with attn_uses_sequence_id=True ' +\
@@ -409,7 +409,7 @@ class MosaicGPT(PreTrainedModel):
             raise NotImplementedError(
                 'MosaicGPT does not support generation with right padding.')
 
-        if self.attn_uses_sequence_id and self.training():
+        if self.attn_uses_sequence_id and self.training:
             sequence_id = torch.zeros_like(input_ids[:1])
         else:
             sequence_id = None

--- a/examples/llm/src/models/mosaic_gpt/mosaic_gpt.py
+++ b/examples/llm/src/models/mosaic_gpt/mosaic_gpt.py
@@ -157,9 +157,9 @@ class MosaicGPT(PreTrainedModel):
             attn_bias = self._apply_prefix_mask(attn_bias, prefix_mask)
 
         # If using torch or triton, we incorporate sequence_id (if appropriate)
-        if self.attn_uses_sequence_id:
+        if self.attn_uses_sequence_id and sequence_id is not None:
             assert isinstance(attn_bias, torch.Tensor)  # pyright
-            assert isinstance(sequence_id, torch.Tensor)  # pyright
+            # assert isinstance(sequence_id, torch.Tensor)  # pyright
             attn_bias = self._apply_sequence_id(attn_bias, sequence_id)
 
         # If using torch or triton, we incorporate attention_mask. This will output
@@ -273,15 +273,15 @@ class MosaicGPT(PreTrainedModel):
                 'prefix_mask is a required argument when MosaicGPT is configured with prefix_lm=True.'
             )
 
-        if self.attn_uses_sequence_id and sequence_id is None:
-            raise ValueError(
-                'sequence_id is a required argument when MosaicGPT is configured with attn_uses_sequence_id=True.'
-            )
-        elif sequence_id is not None:
-            warnings.warn(
-                'MosaicGPT received non-None input for `sequence_id` but is configured with attn_uses_sequence_id=False. ' +\
-                'This input will be ignored. If you want the model to use `sequence_id`, set attn_uses_sequence_id to True.'
-            )
+        # if self.attn_uses_sequence_id and sequence_id is None:
+        #     raise ValueError(
+        #         'sequence_id is a required argument when MosaicGPT is configured with attn_uses_sequence_id=True.'
+        #     )
+        # elif sequence_id is not None:
+        #     warnings.warn(
+        #         'MosaicGPT received non-None input for `sequence_id` but is configured with attn_uses_sequence_id=False. ' +\
+        #         'This input will be ignored. If you want the model to use `sequence_id`, set attn_uses_sequence_id to True.'
+        #     )
 
         S = input_ids.size(1)
 
@@ -406,10 +406,10 @@ class MosaicGPT(PreTrainedModel):
             raise NotImplementedError(
                 'MosaicGPT does not support generation with right padding.')
 
-        if self.attn_uses_sequence_id:
-            sequence_id = torch.zeros_like(input_ids)
-        else:
-            sequence_id = None
+        # if self.attn_uses_sequence_id:
+        #     sequence_id = torch.zeros_like(input_ids)
+        # else:
+        #     sequence_id = None
 
         if past_key_values is not None:
             input_ids = input_ids[:, -1].unsqueeze(-1)
@@ -429,7 +429,7 @@ class MosaicGPT(PreTrainedModel):
             'input_ids': input_ids,
             'attention_mask': attention_mask,
             'prefix_mask': prefix_mask,
-            'sequence_id': sequence_id,
+            # 'sequence_id': sequence_id,
             'past_key_values': past_key_values,
             'use_cache': kwargs.get('use_cache'),
         }

--- a/examples/llm/src/models/mosaic_gpt/mosaic_gpt.py
+++ b/examples/llm/src/models/mosaic_gpt/mosaic_gpt.py
@@ -41,6 +41,7 @@ class MosaicGPT(PreTrainedModel):
 
         self.attn_impl = config.attn_impl
         self.prefix_lm = config.prefix_lm
+        self.attn_uses_sequence_id = config.attn_uses_sequence_id
         self.alibi = config.alibi
         self.alibi_bias_max = config.alibi_bias_max
 
@@ -107,7 +108,8 @@ class MosaicGPT(PreTrainedModel):
             config.max_seq_len,
             self.alibi,
             prefix_lm=self.prefix_lm,
-            causal=self.is_causal)
+            causal=self.is_causal,
+            use_sequence_id=self.attn_uses_sequence_id)
 
         if config.no_bias:
             for module in self.modules():
@@ -124,7 +126,8 @@ class MosaicGPT(PreTrainedModel):
                    device,
                    dtype,
                    attention_mask: Optional[torch.ByteTensor] = None,
-                   prefix_mask: Optional[torch.ByteTensor] = None):
+                   prefix_mask: Optional[torch.ByteTensor] = None,
+                   sequence_id: Optional[torch.LongTensor] = None):
         if not self._attn_bias_initialized:
             if self.attn_bias_shape:
                 self.attn_bias = torch.zeros(self.attn_bias_shape,
@@ -153,8 +156,14 @@ class MosaicGPT(PreTrainedModel):
             assert isinstance(prefix_mask, torch.Tensor)  # pyright
             attn_bias = self._apply_prefix_mask(attn_bias, prefix_mask)
 
+        # If using torch or triton, we incorporate sequence_id (if appropriate)
+        if self.attn_uses_sequence_id:
+            assert isinstance(attn_bias, torch.Tensor)  # pyright
+            assert isinstance(sequence_id, torch.Tensor)  # pyright
+            attn_bias = self._apply_sequence_id(attn_bias, sequence_id)
+
         # If using torch or triton, we incorporate attention_mask. This will output
-        # None in place of attention_mask since it will not be futher needed in the
+        # None in place of attention_mask since it will not be further needed in the
         # attention modules.
         if attention_mask is not None:
             s_k = attention_mask.shape[-1]
@@ -209,12 +218,34 @@ class MosaicGPT(PreTrainedModel):
 
         return attn_bias
 
+    def _apply_sequence_id(self, attn_bias: torch.Tensor,
+                           sequence_id: torch.LongTensor):
+        seq_len = sequence_id.shape[-1]
+        if seq_len > self.config.max_seq_len:
+            raise ValueError(
+                f'sequence_id sequence length cannot exceed max_seq_len={self.config.max_seq_len}'
+            )
+
+        # select seq_len subset of attn mask
+        attn_bias = attn_bias[..., :seq_len, :seq_len]
+
+        # Restrict attention to tokens that share the same value
+        # in sequence_id
+        cannot_attend = torch.logical_not(
+            torch.eq(sequence_id.view(-1, seq_len, 1),
+                     sequence_id.view(-1, 1, seq_len))).unsqueeze(1)
+        min_val = torch.finfo(attn_bias.dtype).min
+        attn_bias = attn_bias.masked_fill(cannot_attend, min_val)
+
+        return attn_bias
+
     def forward(
             self,
             input_ids: torch.LongTensor,
             past_key_values: Optional[List[Tuple[torch.FloatTensor]]] = None,
             attention_mask: Optional[torch.ByteTensor] = None,
             prefix_mask: Optional[torch.ByteTensor] = None,
+            sequence_id: Optional[torch.LongTensor] = None,
             return_dict: Optional[bool] = None,
             output_attentions: Optional[bool] = None,
             output_hidden_states: Optional[bool] = None,
@@ -240,6 +271,16 @@ class MosaicGPT(PreTrainedModel):
         if self.prefix_lm and prefix_mask is None:
             raise ValueError(
                 'prefix_mask is a required argument when MosaicGPT is configured with prefix_lm=True.'
+            )
+
+        if self.attn_uses_sequence_id and sequence_id is None:
+            raise ValueError(
+                'sequence_id is a required argument when MosaicGPT is configured with attn_uses_sequence_id=True.'
+            )
+        elif sequence_id is not None:
+            warnings.warn(
+                'MosaicGPT received non-None input for `sequence_id` but is configured with attn_uses_sequence_id=False. ' +\
+                'This input will be ignored. If you want the model to use `sequence_id`, set attn_uses_sequence_id to True.'
             )
 
         S = input_ids.size(1)
@@ -294,7 +335,8 @@ class MosaicGPT(PreTrainedModel):
             device=x.device,
             dtype=x.dtype,
             attention_mask=attention_mask,
-            prefix_mask=prefix_mask)
+            prefix_mask=prefix_mask,
+            sequence_id=sequence_id)
 
         # initialize the past key values cache if it should be used
         if use_cache and past_key_values is None:
@@ -364,6 +406,11 @@ class MosaicGPT(PreTrainedModel):
             raise NotImplementedError(
                 'MosaicGPT does not support generation with right padding.')
 
+        if self.attn_uses_sequence_id:
+            sequence_id = torch.zeros_like(input_ids)
+        else:
+            sequence_id = None
+
         if past_key_values is not None:
             input_ids = input_ids[:, -1].unsqueeze(-1)
 
@@ -382,6 +429,7 @@ class MosaicGPT(PreTrainedModel):
             'input_ids': input_ids,
             'attention_mask': attention_mask,
             'prefix_mask': prefix_mask,
+            'sequence_id': sequence_id,
             'past_key_values': past_key_values,
             'use_cache': kwargs.get('use_cache'),
         }
@@ -477,12 +525,14 @@ class ComposerMosaicGPT(HuggingFaceModel):
         input_ids = batch['input_ids']
         attention_mask = batch['attention_mask'].bool(
         ) if 'attention_mask' in batch else None
+        sequence_id = batch.get('sequence_id', None)
         prefix_mask = batch['bidirectional_mask'].bool(
         ) if 'bidirectional_mask' in batch else None
         # Note: prefix_mask is only used if model.prefix_lm is True
         return self.model(input_ids=input_ids,
                           attention_mask=attention_mask,
-                          prefix_mask=prefix_mask)
+                          prefix_mask=prefix_mask,
+                          sequence_id=sequence_id)
 
     def loss(self, outputs, batch):
         targets = self.get_targets(batch)

--- a/examples/llm/tests/test_model.py
+++ b/examples/llm/tests/test_model.py
@@ -714,6 +714,7 @@ def test_forward_with_cache_and_padding(alibi):
         resid_pdrop=0.2,
         attn_impl='torch',
         alibi=alibi,
+        use_cache=True,
     )
 
     mosaic_gpt = MosaicGPT(hf_config)
@@ -788,6 +789,7 @@ def test_forward_with_cache(attention_impl, device, alibi):
         resid_pdrop=0.2,
         attn_impl=attention_impl,
         alibi=alibi,
+        use_cache=True,
     )
     reproducibility.seed_all(1234)
     mosaic_gpt = MosaicGPT(hf_config)
@@ -861,6 +863,7 @@ def test_generate_with_past_kv(alibi):
         resid_pdrop=0.2,
         attn_impl='torch',
         alibi=alibi,
+        use_cache=True,
     )
     mosaic_gpt = MosaicGPT(hf_config)
     mosaic_gpt.eval()
@@ -914,6 +917,7 @@ def test_generation_kwargs_dont_crash(generation_kwargs, alibi):
         resid_pdrop=0.2,
         attn_impl='torch',
         alibi=alibi,
+        use_cache=True,
     )
     mosaic_gpt = MosaicGPT(hf_config)
     mosaic_gpt.eval()


### PR DESCRIPTION
Makes it possible to have attention restricted to tokens within the same source sequence when using pre-concatenated text dataloading.

- Adds `eos_token_id` and `bos_token_id` flags for the `text` dataloader, which instructs it to add `"sequence_id"` to the batch using one of those tokens as the separator.
- Adds `attn_uses_sequence_id` flag to MosaicGPT config/model and `sequence_id` to the forward arguments.
- Modifies the attention bias construction to restrict attention based on `sequence_id` if the model config is set to use that input.

125m comparison: https://wandb.ai/mosaic-ml/v004-125m
3b comparison: https://wandb.ai/mosaic-ml/v004-3b/table?workspace=user-alextrott (for profiling; not a full convergence run)