### PR TITLE
Add bin packing collator wrapper in denoising

### DIFF
--- a/examples/llm/src/data/denoising.py
+++ b/examples/llm/src/data/denoising.py
@@ -16,6 +16,7 @@ from torch.utils.data import DataLoader
 from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
 
 from examples.common.text_data import StreamingTextDataset
+from examples.llm.src.data.packing import BinPackWrapper
 from examples.llm.src.models import utils
 
 __all__ = ['MixtureOfDenoisersCollator', 'build_text_denoising_dataloader']
@@ -122,6 +123,11 @@ class MixtureOfDenoisersCollator:
             To disable these prefixes, use a value of ``None``.
             Default: :func:`ul2_prefix_function` applies the prefix scheme
             suggested in the UL2 paper: http://arxiv.org/abs/2205.05131.
+        context_eos (bool, optional): Whether to attach an EOS token to the end
+            of the context sequence, marking the transition from context to
+            target sequence. Only applicable if decoder_only_format is True.
+            Context EOS tokens are always added for encoder-decoder format.
+            Default: ``False`` does not attach context EOS.
     """
 
     def __init__(
@@ -133,6 +139,7 @@ class MixtureOfDenoisersCollator:
         sequence_mask_ratios: Optional[Union[List[float], float]] = None,
         allow_pad_trimming: bool = False,
         prefix_function: Optional[PREFIX_FUNCTION] = ul2_prefix_function,
+        context_eos: Optional[bool] = None,
     ):
         self.tokenizer = tokenizer
         self.max_seq_length = max_seq_length
@@ -142,6 +149,13 @@ class MixtureOfDenoisersCollator:
         # Trimming will always be skipped on at least the first __call__
         self._allow_pad_trimming = allow_pad_trimming
         self._seen_first_batch = False
+
+        if decoder_only_format:
+            if context_eos is None:
+                context_eos = False
+        else:
+            context_eos = True
+        self.context_eos = bool(context_eos)
 
         # Prepare the tokenizer for denoising tasks
         utils.adapt_tokenizer_for_denoising(self.tokenizer)
@@ -212,7 +226,8 @@ class MixtureOfDenoisersCollator:
                 mask_ratio=span_mask_ratio,
                 mean_span_length=span_mean_length,
                 n_prefix_tokens=len(prefix_tokens or []),
-                decoder_only_format=self.decoder_only_format)
+                decoder_only_format=self.decoder_only_format,
+                context_eos=self.context_eos)
             if max_raw_length < self._smallest_max_raw_length:
                 self._smallest_max_raw_length = max_raw_length
             if max_raw_length > self._largest_max_raw_length:
@@ -235,6 +250,8 @@ class MixtureOfDenoisersCollator:
                 prefix_tokens = None
 
             max_raw_length = self.max_seq_length - len(prefix_tokens or []) - 1
+            if decoder_only_format and self.context_eos:
+                max_raw_length = max_raw_length - 1
 
             if not self._uses_span_corruption and (
                     max_raw_length < self._smallest_max_raw_length):
@@ -283,7 +300,8 @@ class MixtureOfDenoisersCollator:
                     max_seq_length=self.max_seq_length,
                     tokenizer=self.tokenizer,
                     sentinel_token_ids=self._sentinel_token_ids,
-                    decoder_only_format=self.decoder_only_format))
+                    decoder_only_format=self.decoder_only_format,
+                    context_eos=self.context_eos))
         batch = self.tokenizer.pad(processed_examples)
 
         # This logic prevents trimming on at least the first batch
@@ -361,6 +379,18 @@ def build_text_denoising_dataloader(cfg: DictConfig,
             cfg.dataset.max_seq_len (int): The maximum length of sequences
                 in the batch. See :class:`MixtureOfDenoisersCollator` docstring
                 for details.
+            cfg.dataset.packing_ratio (float, optional): If provided, this invokes
+                a collator wrapper that packs device_batch_size*packing_ratio
+                raw examples into device_batch_size packed examples. This helps
+                minimize padding while preserving sequence integrity.
+                This adds `sequence_id` to the batch, which indicates which unique
+                sequence each token belongs to.
+                Note: Using this feature will not change device_batch_size but it
+                    will determine the number of raw examples consumed by the dataloader
+                    per batch. Some examples may be discarded if they do not fit when
+                    packing.
+                    Select packing_ratio **carefully** based on the dataset
+                    statistics, max_seq_len, and tolerance for discarding samples!
             See :class:`StreamingTextDataset` for info on other standard config
                 options within `cfg.dataset`.
             ---
@@ -401,7 +431,8 @@ def build_text_denoising_dataloader(cfg: DictConfig,
         allow_pad_trimming=cfg.mixture_of_denoisers.get('allow_pad_trimming',
                                                         False),
         prefix_function=cfg.mixture_of_denoisers.get('prefix_function',
-                                                     ul2_prefix_function))
+                                                     ul2_prefix_function),
+        context_eos=cfg.mixture_of_denoisers.get('context_eos'))
 
     truncate_to = cfg.mixture_of_denoisers.get('truncate_raw_tokens_to')
     if truncate_to is None:
@@ -444,6 +475,24 @@ def build_text_denoising_dataloader(cfg: DictConfig,
         num_canonical_nodes=cfg.dataset.get('num_canonical_nodes'),
         batch_size=device_batch_size)
 
+    if dataset.tokenizer.pad_token is None:  # type: ignore
+        dataset.tokenizer.pad_token = dataset.tokenizer.eos_token
+
+    if cfg.dataset.get('packing_ratio'):
+        n_examples_to_pack = int(device_batch_size * cfg.dataset.packing_ratio)
+        if n_examples_to_pack < device_batch_size:
+            raise ValueError('packing_ratio must be >= 1, if supplied')
+        if not cfg.mixture_of_denoisers.decoder_only_format:
+            raise NotImplementedError(
+                'On-the-fly packing is currently only supported for decoder-only formats.'
+            )
+        collate_fn = BinPackWrapper(collator=collate_fn,
+                                    target_batch_size=device_batch_size,
+                                    max_seq_len=cfg.dataset.max_seq_len,
+                                    pad_token_id=dataset.tokenizer.pad_token_id,
+                                    padding_side=dataset.tokenizer.padding_side)
+        device_batch_size = n_examples_to_pack
+
     return DataLoader(
         dataset,
         collate_fn=collate_fn,
@@ -467,6 +516,7 @@ def noise_token_sequence(
     tokenizer: Tokenizer,
     sentinel_token_ids: np.ndarray,
     decoder_only_format: bool,
+    context_eos: bool,
 ) -> Dict[str, torch.Tensor]:
     """Span corruption applicable to all UL2 denoising tasks."""
     # Extract the raw text tokens (trim if we need to)
@@ -504,7 +554,6 @@ def noise_token_sequence(
         use_sentinels = False
     else:
         use_sentinels = True
-    ensure_input_eos = False if decoder_only_format else True
 
     # Generate the mask
     # Note: this function can be used for all the UL2 noising functions
@@ -518,7 +567,7 @@ def noise_token_sequence(
                                 use_sentinels,
                                 tokenizer.eos_token_id,
                                 sentinel_token_ids,
-                                ensure_eos=ensure_input_eos)
+                                ensure_eos=context_eos)
     tokens_labels = _apply_mask(tokens,
                                 1 - mask,
                                 use_sentinels,
@@ -551,7 +600,7 @@ def noise_token_sequence(
 
 def _get_max_starting_length(max_length: int, mask_ratio: float,
                              mean_span_length: float, n_prefix_tokens: int,
-                             decoder_only_format: bool):
+                             decoder_only_format: bool, context_eos: bool):
     """Get max num raw tokens that will fit max_length."""
 
     def sequence_stats(length: int):
@@ -563,8 +612,7 @@ def _get_max_starting_length(max_length: int, mask_ratio: float,
         num_noise_spans = np.maximum(num_spans, 1)
         num_nonnoise_tokens = length - num_noise_tokens
         # Prefix, sentinel, and EOS added to input for Enc-Dec
-        extra_inp_tokens = n_prefix_tokens + num_noise_spans + int(
-            not decoder_only_format)
+        extra_inp_tokens = n_prefix_tokens + num_noise_spans + int(context_eos)
         # Sentinel and EOS added to target
         extra_targ_tokens = num_noise_spans + 1
         # Sequence totals after corruption
@@ -763,7 +811,7 @@ def _format_tokens_for_decoder_only(
 
 
 # Helpful to test if your dataloader is working locally
-# Run `python data_denoising.py [remote] [local, optional]` and verify that batches
+# Run `python denoising.py [remote] [local, optional]` and verify that batches
 # are printed out
 if __name__ == '__main__':
     remote = sys.argv[1]
@@ -783,7 +831,8 @@ if __name__ == '__main__':
             'split': 'val_small',
             'shuffle': False,
             'tokenizer_name': 'gpt2' if decoder_only else 't5-base',
-            'max_seq_len': 256 if decoder_only else 128,
+            'max_seq_len': 2048 if decoder_only else 1024,
+            'packing_ratio': 5.0,
             'predownload': 1000,
             'keep_zip': True,  # in case we need compressed files after testing
         },
@@ -803,9 +852,21 @@ if __name__ == '__main__':
     print(
         f'\n\nTRUNCATING TO: {loader.dataset.max_seq_len}\n\n')  # type: ignore
 
-    tokenizer = loader.collate_fn.tokenizer
+    packing = cfg.dataset.get('packing_ratio') is not None
+    if packing:
+        tokenizer = loader.collate_fn.base_collator.tokenizer
+    else:
+        tokenizer = loader.collate_fn.tokenizer
     batch_ix = 0
     for batch in loader:
+        if batch_ix >= 50:
+            batch_ix += 1
+            break
+        if batch_ix >= 5:
+            if not packing:
+                break
+            batch_ix += 1
+            continue
         print('\n')
         print('#' * 20, f'Batch {batch_ix}', '#' * 20)
         for k, v in batch.items():
@@ -818,16 +879,24 @@ if __name__ == '__main__':
                 attn_full = batch['attention_mask'][sample_ix].to(torch.bool)
                 attn_labels = torch.logical_xor(attn_inputs, attn_full)
                 print('-' * 20, f' Sample {sample_ix} ', '-' * 20)
-                print('Input:  ', tokenizer.decode(token_sample[attn_inputs]))
-                print('Target: ', tokenizer.decode(labels[attn_labels]))
+                print('\033[91m{}\033[00m\n'.format('Full:   '),
+                      tokenizer.decode(token_sample[attn_full]))
+                print('\033[93m{}\033[00m\n'.format('Input:  '),
+                      tokenizer.decode(token_sample[attn_inputs]))
+                print('\033[92m{}\033[00m\n'.format('Target: '),
+                      tokenizer.decode(labels[attn_labels]))
             else:
                 labels = batch['labels'][sample_ix]
                 attn_inputs = batch['attention_mask'][sample_ix].to(torch.bool)
                 attn_labels = batch['decoder_attention_mask'][sample_ix].to(
                     torch.bool)
                 print('-' * 20, f' Sample {sample_ix} ', '-' * 20)
-                print('Input:  ', tokenizer.decode(token_sample[attn_inputs]))
-                print('Target: ', tokenizer.decode(labels[attn_labels]))
+                print('\033[93m{}\033[00m\n'.format('Input:  '),
+                      tokenizer.decode(token_sample[attn_inputs]))
+                print('\033[92m{}\033[00m\n'.format('Target: '),
+                      tokenizer.decode(labels[attn_labels]))
         batch_ix += 1
-        if batch_ix >= 5:
-            break
+
+    if packing:
+        print(f'Padding = {100*(1-loader.collate_fn.efficiency):5.2f}%')
+        print(f'Waste   = {100*loader.collate_fn.waste:5.2f}%')

--- a/examples/llm/src/data/packing.py
+++ b/examples/llm/src/data/packing.py
@@ -1,0 +1,204 @@
+# Copyright 2022 MosaicML Examples authors
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Callable, Dict, List, Literal, Tuple
+
+import torch
+
+
+class BinPackWrapper:
+    """Utility collator for packing to reduce padding."""
+
+    def __init__(self, collator: Callable, target_batch_size: int,
+                 max_seq_len: int, pad_token_id: int,
+                 padding_side: Literal['left', 'right']):
+        self.base_collator = collator
+        self.out_size = int(target_batch_size)
+        self.max_seq_len = int(max_seq_len)
+        self.pad_token_id = int(pad_token_id)
+        assert self.out_size > 0
+        assert self.max_seq_len > 0
+        assert self.pad_token_id > 0
+
+        self.padding_side = padding_side
+
+        self.n_packed_tokens = 0
+        self.n_total_tokens = 0
+        self.n_packed_examples = 0
+
+    @property
+    def waste(self):
+        return 1 - (self.n_packed_tokens / self.n_total_tokens)
+
+    @property
+    def efficiency(self):
+        return self.n_packed_tokens / (self.max_seq_len *
+                                       self.n_packed_examples)
+
+    def __call__(
+            self,
+            examples: List[Dict[str, torch.Tensor]]) -> Dict[str, torch.Tensor]:
+        batch = self.base_collator(examples)
+
+        assert 'attention_mask' in batch
+        assert 'input_ids' in batch
+
+        for key in batch.keys():
+            assert key in [
+                'input_ids',
+                'labels',
+                'attention_mask',
+                'bidirectional_mask',
+            ]
+
+        # Cut everything down to size
+        sizes, trimmed_examples = [], []
+        for idx in range(batch['attention_mask'].shape[0]):
+            size, trimmed_example = extract_trim_batch_idx(batch, idx)
+            sizes.append(size)
+            trimmed_examples.append(trimmed_example)
+
+        bin_examples, n_discarded_tokens, n_total_tokens = first_fit_bin_packing(
+            sizes=sizes, num_bins=self.out_size, max_bin_size=self.max_seq_len)
+        self.n_packed_tokens += (n_total_tokens - n_discarded_tokens)
+        self.n_total_tokens += n_total_tokens
+        self.n_packed_examples += self.out_size
+
+        # Merge the examples within each bin
+        packed_examples = []
+        for example_indices in bin_examples:
+            first_bin_index = example_indices[0]
+            packed_example = trimmed_examples[first_bin_index]
+            for example_index in example_indices[1:]:
+                packed_example = combine_in_place(
+                    packed_example, trimmed_examples[example_index])
+            packed_examples.append(packed_example)
+
+        # Re-pad to max_seq_len and batch
+        batch = repad(packed_examples,
+                      max_seq_len=self.max_seq_len,
+                      pad_token_id=self.pad_token_id,
+                      padding_side=self.padding_side)
+        return batch
+
+
+def extract_trim_batch_idx(batch: Dict[str, torch.Tensor], idx: int):
+    example = {k: v[idx] for k, v in batch.items()}
+
+    keep = example['attention_mask'] == 1
+    size = int(keep.sum())
+    trim_example = {k: v[keep] for k, v in example.items()}
+    trim_example['sequence_id'] = torch.zeros_like(trim_example['input_ids'])
+
+    return size, trim_example
+
+
+def combine_in_place(example: Dict[str, torch.Tensor],
+                     add_on: Dict[str, torch.Tensor]):
+    if 'labels' in add_on:
+        # Prevents the last token in example from being trained to
+        # predict the first token in add_on, which would make no sense.
+        add_on['labels'][0] = -100
+
+    for k in example.keys():
+        if k == 'sequence_id':
+            example[k] = torch.cat(
+                [example[k], add_on[k] + 1 + torch.max(example[k])])
+        else:
+            example[k] = torch.cat([example[k], add_on[k]])
+    return example
+
+
+def first_fit_bin_packing(
+        sizes: List[int], num_bins: int,
+        max_bin_size: int) -> Tuple[List[List[int]], int, int]:
+    num_examples = len(sizes)
+    if num_examples < num_bins:
+        raise ValueError(f'Cannot pack {num_examples=} into {num_bins=}.')
+
+    sizes_and_indices = [(size, idx) for idx, size in enumerate(sizes)]
+    sorted_sizes_and_indices = sorted(sizes_and_indices,
+                                      key=lambda x: x[0],
+                                      reverse=True)
+
+    # Will contain tuples (total_size, [indices])
+    bins: List[Tuple[int, List[int]]] = []
+
+    # Go through each item from longest to shortest.
+    # Note: all items will either go into an existing or new bin.
+    for i, (size, index) in enumerate(sorted_sizes_and_indices):
+        # If we can't keep packing, all remaining items get their own bin.
+        n_remaining = num_examples - i
+        assert n_remaining + len(bins) >= num_bins
+        if n_remaining + len(bins) == num_bins:
+            # Can't keep packing. All remaining items get their own bin.
+            bins.append((size, [index]))
+            continue
+
+        # Add it to the first bin it fits in
+        added = False
+        for bidx in range(len(bins)):
+            if bins[bidx][0] + size <= max_bin_size:
+                bin_size, bin_indices = bins.pop(bidx)
+                bin_size = bin_size + size
+                bin_indices.append(index)
+                bins.append((bin_size, bin_indices))
+                added = True
+                break
+        # If it didn't fit anywhere, open a new bin
+        if not added:
+            bins.append((size, [index]))
+
+    total_bin_sizes = sum([bin_size for bin_size, _ in bins])
+    total_example_sizes = sum(sizes)
+    if total_bin_sizes != total_example_sizes:
+        raise AssertionError(
+            f'Error in packing. {total_example_sizes=} does not equal {total_bin_sizes=}.'
+        )
+
+    sorted_bins = sorted(bins, key=lambda x: x[0], reverse=True)
+    bin_sizes, bin_indices = [], []
+    for bin_size, bin_indices_ in sorted_bins:
+        bin_sizes.append(bin_size)
+        bin_indices.append(bin_indices_)
+
+    # waste is the total size of discarded bins
+    waste = sum(bin_sizes[num_bins:])
+
+    # Return the num_bins largest bins, the "waste", and the total starting size
+    return bin_indices[:num_bins], waste, sum(sizes)
+
+
+def repad(packed_examples: List[Dict[str, torch.Tensor]], max_seq_len: int,
+          pad_token_id: int, padding_side: str) -> Dict[str, torch.Tensor]:
+
+    def pad_tensor(tensor: torch.Tensor, pad_value: int):
+        if len(tensor) == max_seq_len:
+            return tensor
+        t = torch.full((max_seq_len,),
+                       pad_value,
+                       dtype=tensor.dtype,
+                       device=tensor.device)
+        if padding_side == 'left':
+            t[-len(tensor):] = tensor
+        elif padding_side == 'right':
+            t[:len(tensor)] = tensor
+        else:
+            raise ValueError(f'Unknown {padding_side=}')
+        return t
+
+    pad_vals = {
+        'input_ids': pad_token_id,
+        'labels': -100,
+        'attention_mask': 0,
+        'bidirectional_mask': 0,
+        'sequence_id': -1,
+    }
+    keys = packed_examples[0].keys()
+    batch = {}
+    for key in keys:
+        batch[key] = torch.stack([
+            pad_tensor(example[key], pad_vals[key])
+            for example in packed_examples
+        ])
+    return batch


### PR DESCRIPTION
Provides way to get concatenation and `"sequence_id"` support from raw text data in `denoising.py`.

Note: this PR also folds in a minor feature addition to the mixture-of-denoisers collator, which controls whether an EOS tag is appended to the end of the context (i.e. "prefix"). This feature is off by default.