### PR TITLE
Update training YAMLs with new defaults

### DIFF
--- a/examples/llm/icl_eval/yamls/gpt_neo_eval.yaml
+++ b/examples/llm/icl_eval/yamls/gpt_neo_eval.yaml
@@ -16,6 +16,7 @@ load_path: # Add your (optional) Composer checkpoint path here!
 # FSDP config for model sharding
 # fsdp_config:
 #   sharding_strategy: FULL_SHARD
+#   mixed_precision: PURE
 
 icl_tasks:
 -

--- a/examples/llm/icl_eval/yamls/mosaic_gpt_eval.yaml
+++ b/examples/llm/icl_eval/yamls/mosaic_gpt_eval.yaml
@@ -1,18 +1,21 @@
+max_seq_len: 2048
+tokenizer_name: gpt2
+
 tokenizer:
   type: hftokenizer
   args:
-    tokenizer_name: gpt2
-    max_seq_len: 2048
+    tokenizer_name: ${tokenizer_name}
+    max_seq_len: ${max_seq_len}
 
 model:
   name: mosaic_gpt
   init_device: meta
-  tokenizer_name: gpt2
+  tokenizer_name: ${tokenizer_name}
   d_model: 768
   n_heads: 12
   n_layers: 12
   mlp_ratio: 4
-  max_seq_len: 2048
+  max_seq_len: ${max_seq_len}
   vocab_size: 50368
   attn_impl: triton
 

--- a/examples/llm/icl_eval/yamls/mosaic_gpt_eval.yaml
+++ b/examples/llm/icl_eval/yamls/mosaic_gpt_eval.yaml
@@ -13,11 +13,7 @@ model:
   n_layers: 12
   mlp_ratio: 4
   max_seq_len: 2048
-  vocab_size: 50257
-  init_std: 0.02
-  attn_pdrop: 0.0
-  resid_pdrop: 0.0
-  emb_pdrop: 0.0
+  vocab_size: 50368
   attn_impl: triton
 
 load_path: # Add your (optional) Composer checkpoint path here!

--- a/examples/llm/icl_eval/yamls/mosaic_gpt_eval.yaml
+++ b/examples/llm/icl_eval/yamls/mosaic_gpt_eval.yaml
@@ -25,6 +25,7 @@ load_path: # Add your (optional) Composer checkpoint path here!
 # FSDP config for model sharding
 # fsdp_config:
 #   sharding_strategy: FULL_SHARD
+#   mixed_precision: PURE
 
 icl_tasks:
 -

--- a/examples/llm/icl_eval/yamls/mosaic_gpt_eval.yaml
+++ b/examples/llm/icl_eval/yamls/mosaic_gpt_eval.yaml
@@ -18,7 +18,7 @@ model:
   attn_pdrop: 0.0
   resid_pdrop: 0.0
   emb_pdrop: 0.0
-  attn_impl: flash
+  attn_impl: triton
 
 load_path: # Add your (optional) Composer checkpoint path here!
 

--- a/examples/llm/mcloud/mcli-1b-eval.yaml
+++ b/examples/llm/mcloud/mcli-1b-eval.yaml
@@ -38,10 +38,6 @@ parameters:
     mlp_ratio: 4
     max_seq_len: 2048
     vocab_size: 50368
-    init_std: 0.02
-    attn_pdrop: 0.0
-    resid_pdrop: 0.0
-    emb_pdrop: 0.0
     attn_impl: triton
 
   load_path: # Add your (optional) Composer checkpoint path here!

--- a/examples/llm/mcloud/mcli-1b-eval.yaml
+++ b/examples/llm/mcloud/mcli-1b-eval.yaml
@@ -42,7 +42,7 @@ parameters:
     attn_pdrop: 0.0
     resid_pdrop: 0.0
     emb_pdrop: 0.0
-    attn_impl: flash
+    attn_impl: triton
 
   load_path: # Add your (optional) Composer checkpoint path here!
 

--- a/examples/llm/mcloud/mcli-1b-eval.yaml
+++ b/examples/llm/mcloud/mcli-1b-eval.yaml
@@ -22,21 +22,24 @@ cluster: r0z0 # replace with your cluster here!
 
 # The below is injected as a YAML file: /mnt/config/parameters.yaml
 parameters:
+  tokenizer_name: gpt2
+  max_seq_len: 2048
+
   tokenizer:
     type: hftokenizer
     args:
-      tokenizer_name: gpt2
-      max_seq_len: 2048
+      tokenizer_name: ${tokenizer_name}
+      max_seq_len: ${max_seq_len}
 
   model:
     name: mosaic_gpt
     init_device: meta
-    tokenizer_name: gpt2
+    tokenizer_name: ${tokenizer_name}
     d_model: 2048
     n_heads: 16 # Modified 24->16 so that d_head == 128 to statisfy FlashAttention
     n_layers: 24
     mlp_ratio: 4
-    max_seq_len: 2048
+    max_seq_len: ${max_seq_len}
     vocab_size: 50368
     attn_impl: triton
 
@@ -45,6 +48,8 @@ parameters:
   # FSDP config for model sharding
   fsdp_config:
     sharding_strategy: FULL_SHARD
+    mixed_precision: PURE
+
 
   icl_tasks:
   -

--- a/examples/llm/mcloud/mcli-1b-max-seq-len-8k.yaml
+++ b/examples/llm/mcloud/mcli-1b-max-seq-len-8k.yaml
@@ -123,7 +123,9 @@ parameters:
     sharding_strategy: FULL_SHARD
     mixed_precision: PURE
     activation_checkpointing: false
+    activation_checkpointing_reentrant: false
     activation_cpu_offload: false
+    limit_all_gathers: true
     verbose: false
 
   # Logging

--- a/examples/llm/mcloud/mcli-1b-max-seq-len-8k.yaml
+++ b/examples/llm/mcloud/mcli-1b-max-seq-len-8k.yaml
@@ -46,10 +46,6 @@ parameters:
     mlp_ratio: 4
     max_seq_len: ${max_seq_len}
     vocab_size: 50368
-    init_std: 0.02
-    attn_pdrop: 0.0
-    resid_pdrop: 0.0
-    emb_pdrop: 0.0
     attn_impl: triton
 
   # Tokenizer

--- a/examples/llm/mcloud/mcli-1b-max-seq-len-8k.yaml
+++ b/examples/llm/mcloud/mcli-1b-max-seq-len-8k.yaml
@@ -50,7 +50,7 @@ parameters:
     attn_pdrop: 0.0
     resid_pdrop: 0.0
     emb_pdrop: 0.0
-    attn_impl: flash
+    attn_impl: triton
 
   # Tokenizer
   tokenizer:
@@ -108,6 +108,7 @@ parameters:
 
   max_duration: 24800ba # ~ 26B tokens
   eval_interval: 2000ba
+  eval_first: false
   eval_subset_num_batches: -1
   global_train_batch_size: 128 # ~1M tokens
 

--- a/examples/llm/mcloud/mcli-1b-max-seq-len-8k.yaml
+++ b/examples/llm/mcloud/mcli-1b-max-seq-len-8k.yaml
@@ -121,7 +121,7 @@ parameters:
   # FSDP
   fsdp_config:
     sharding_strategy: FULL_SHARD
-    mixed_precision: DEFAULT
+    mixed_precision: PURE
     activation_checkpointing: false
     activation_cpu_offload: false
     verbose: false

--- a/examples/llm/src/models/mosaic_gpt/configuration_mosaic_gpt.py
+++ b/examples/llm/src/models/mosaic_gpt/configuration_mosaic_gpt.py
@@ -19,7 +19,6 @@ class MosaicGPTConfig(PretrainedConfig):
         mlp_ratio: int = 4,
         max_seq_len: int = 2048,
         vocab_size: int = 50368,
-        init_std: float = 0.02,
         attn_pdrop: float = 0.0,
         resid_pdrop: float = 0.0,
         emb_pdrop: float = 0.0,
@@ -35,16 +34,17 @@ class MosaicGPTConfig(PretrainedConfig):
         logit_scale: Optional[Union[float, str]] = None,
         no_bias: bool = False,
         verbose: int = 0,
-        param_init_fn: str = 'baseline_',
+        param_init_fn: str = 'kaiming_normal_',
         init_div_is_residual: Union[int, float, str, bool] = True,
+        init_std: float = 0.02,
         emb_init_std: Optional[float] = None,
         emb_init_uniform_lim: Optional[Union[Tuple[float, float],
                                              float]] = None,
         init_gain: float = 0,
         fan_mode: str = 'fan_in',
-        init_nonlinearity: str = 'leaky_relu',
+        init_nonlinearity: str = 'relu',
         embedding_fraction: float = 1.0,
-        low_precision_layernorm: bool = False,
+        low_precision_layernorm: bool = True,
         use_cache: bool = False,
         **kwargs,
     ):
@@ -57,8 +57,6 @@ class MosaicGPTConfig(PretrainedConfig):
             mlp_ratio (int): The ratio of the up/down scale in the MLP.
             max_seq_len (int): The maximum sequence length of the model.
             vocab_size (int): The size of the vocabulary.
-            init_std (float): The standard deviation of the normal distribution used to initialize the model,
-                if using the normal parameter initialization scheme.
             attn_pdrop (float): The dropout probability for the attention layers.
             resid_pdrop (float): The dropout probability applied to the attention output before combining with residual.
             emb_pdrop (float): The dropout probability for the embedding layer.
@@ -84,6 +82,8 @@ class MosaicGPTConfig(PretrainedConfig):
             param_init_fn (str): The parameter initialization scheme to use. One of 'default_', 'baseline_', 'kaiming_uniform_',
                 'kaiming_normal_', 'neox_init_', 'small_init_', 'xavier_uniform_', or 'xavier_normal_'.
             init_div_is_residual (Union[int, float, str, bool]): Value to divide initial weights by if ``module._is_residual`` is True.
+            init_std (float): The standard deviation of the normal distribution used to initialize the model,
+                if using the baseline_ parameter initialization scheme.
             emb_init_std (Optional[float]): The standard deviation of the normal distribution used to initialize the embedding layer.
             emb_init_uniform_lim (Optional[Union[Tuple[float, float], float]]): The lower and upper limits of the uniform distribution
                 used to initialize the embedding layer. Mutually exclusive with ``emb_init_std``.
@@ -100,7 +100,6 @@ class MosaicGPTConfig(PretrainedConfig):
         self.mlp_ratio = mlp_ratio
         self.max_seq_len = max_seq_len
         self.vocab_size = vocab_size
-        self.init_std = init_std
         self.attn_pdrop = attn_pdrop
         self.resid_pdrop = resid_pdrop
         self.emb_pdrop = emb_pdrop
@@ -118,6 +117,7 @@ class MosaicGPTConfig(PretrainedConfig):
         self.verbose = verbose
         self.param_init_fn = param_init_fn
         self.init_div_is_residual = init_div_is_residual
+        self.init_std = init_std
         self.emb_init_std = emb_init_std
         self.emb_init_uniform_lim = emb_init_uniform_lim
         self.init_std = init_std

--- a/examples/llm/tests/test_model.py
+++ b/examples/llm/tests/test_model.py
@@ -752,7 +752,6 @@ def test_save_from_pretrained(tmp_path):
 
 
 @pytest.mark.parametrize('alibi', [True, False])
-@pytest.mark.parametrize('low_precision_layernorm', [True, False])
 def test_forward_with_cache_and_padding(alibi):
     # Tests that the result is the same with or without padding when using kv caching
     hf_config = MosaicGPTConfig(
@@ -766,7 +765,6 @@ def test_forward_with_cache_and_padding(alibi):
         resid_pdrop=0.2,
         attn_impl='torch',
         alibi=alibi,
-        low_precision_layernorm=low_precision_layernorm,
         use_cache=True,
     )
 
@@ -810,8 +808,8 @@ def test_forward_with_cache_and_padding(alibi):
     torch.testing.assert_close(second_output_no_padding.logits,
                                second_output_padding.logits[:,
                                                             -1, :].unsqueeze(1),
-                               atol=1e-6,
-                               rtol=1e-6)
+                               atol=1e-5,
+                               rtol=1e-5)
 
 
 @pytest.mark.parametrize('attention_impl,device', [('torch', 'cpu'),

--- a/examples/llm/tests/test_model.py
+++ b/examples/llm/tests/test_model.py
@@ -752,6 +752,7 @@ def test_save_from_pretrained(tmp_path):
 
 
 @pytest.mark.parametrize('alibi', [True, False])
+@pytest.mark.parametrize('low_precision_layernorm', [True, False])
 def test_forward_with_cache_and_padding(alibi):
     # Tests that the result is the same with or without padding when using kv caching
     hf_config = MosaicGPTConfig(
@@ -765,6 +766,7 @@ def test_forward_with_cache_and_padding(alibi):
         resid_pdrop=0.2,
         attn_impl='torch',
         alibi=alibi,
+        low_precision_layernorm=low_precision_layernorm,
         use_cache=True,
     )
 

--- a/examples/llm/yamls/hf_causal_lm/gpt-neo-125m.yaml
+++ b/examples/llm/yamls/hf_causal_lm/gpt-neo-125m.yaml
@@ -85,7 +85,7 @@ precision: amp_bf16
 # FSDP
 fsdp_config:
   sharding_strategy: FULL_SHARD
-  mixed_precision: DEFAULT
+  mixed_precision: PURE
   activation_checkpointing: false
   activation_cpu_offload: false
   verbose: false

--- a/examples/llm/yamls/hf_causal_lm/gpt-neo-125m.yaml
+++ b/examples/llm/yamls/hf_causal_lm/gpt-neo-125m.yaml
@@ -87,7 +87,9 @@ fsdp_config:
   sharding_strategy: FULL_SHARD
   mixed_precision: PURE
   activation_checkpointing: false
+  activation_checkpointing_reentrant: false
   activation_cpu_offload: false
+  limit_all_gathers: true
   verbose: false
 
 # Logging

--- a/examples/llm/yamls/hf_causal_lm/gpt-neo-125m.yaml
+++ b/examples/llm/yamls/hf_causal_lm/gpt-neo-125m.yaml
@@ -72,6 +72,7 @@ algorithms:
 
 max_duration: 4800ba # ~ 2.5B tokens
 eval_interval: 500ba
+eval_first: false
 eval_subset_num_batches: -1
 global_train_batch_size: 256
 

--- a/examples/llm/yamls/hf_causal_lm/gpt2-small.yaml
+++ b/examples/llm/yamls/hf_causal_lm/gpt2-small.yaml
@@ -85,7 +85,7 @@ precision: amp_bf16
 # FSDP
 fsdp_config:
   sharding_strategy: FULL_SHARD
-  mixed_precision: DEFAULT
+  mixed_precision: PURE
   activation_checkpointing: false
   activation_cpu_offload: false
   verbose: false

--- a/examples/llm/yamls/hf_causal_lm/gpt2-small.yaml
+++ b/examples/llm/yamls/hf_causal_lm/gpt2-small.yaml
@@ -87,7 +87,9 @@ fsdp_config:
   sharding_strategy: FULL_SHARD
   mixed_precision: PURE
   activation_checkpointing: false
+  activation_checkpointing_reentrant: false
   activation_cpu_offload: false
+  limit_all_gathers: true
   verbose: false
 
 # Logging

--- a/examples/llm/yamls/hf_causal_lm/gpt2-small.yaml
+++ b/examples/llm/yamls/hf_causal_lm/gpt2-small.yaml
@@ -72,6 +72,7 @@ algorithms:
 
 max_duration: 4800ba # ~ 2.5B tokens
 eval_interval: 500ba
+eval_first: false
 eval_subset_num_batches: -1
 global_train_batch_size: 256
 

--- a/examples/llm/yamls/hf_causal_lm/opt.yaml
+++ b/examples/llm/yamls/hf_causal_lm/opt.yaml
@@ -83,7 +83,9 @@ fsdp_config:
   sharding_strategy: FULL_SHARD
   mixed_precision: PURE
   activation_checkpointing: false
+  activation_checkpointing_reentrant: false
   activation_cpu_offload: false
+  limit_all_gathers: true
   verbose: false
 
 # Logging

--- a/examples/llm/yamls/hf_causal_lm/opt.yaml
+++ b/examples/llm/yamls/hf_causal_lm/opt.yaml
@@ -68,6 +68,7 @@ algorithms:
 
 max_duration: 4800ba # ~ 2.5B tokens
 eval_interval: 500ba
+eval_first: false
 eval_subset_num_batches: -1
 global_train_batch_size: 256
 

--- a/examples/llm/yamls/hf_causal_lm/opt.yaml
+++ b/examples/llm/yamls/hf_causal_lm/opt.yaml
@@ -81,7 +81,7 @@ precision: amp_bf16
 # FSDP
 fsdp_config:
   sharding_strategy: FULL_SHARD
-  mixed_precision: DEFAULT
+  mixed_precision: PURE
   activation_checkpointing: false
   activation_cpu_offload: false
   verbose: false

--- a/examples/llm/yamls/mosaic_gpt/125m.yaml
+++ b/examples/llm/yamls/mosaic_gpt/125m.yaml
@@ -22,7 +22,7 @@ model:
   attn_pdrop: 0.0
   resid_pdrop: 0.0
   emb_pdrop: 0.0
-  attn_impl: flash
+  attn_impl: triton
 
 # Tokenizer
 tokenizer:

--- a/examples/llm/yamls/mosaic_gpt/125m.yaml
+++ b/examples/llm/yamls/mosaic_gpt/125m.yaml
@@ -94,7 +94,9 @@ fsdp_config:
   sharding_strategy: FULL_SHARD
   mixed_precision: PURE
   activation_checkpointing: false
+  activation_checkpointing_reentrant: false
   activation_cpu_offload: false
+  limit_all_gathers: true
   verbose: false
 
 # Logging

--- a/examples/llm/yamls/mosaic_gpt/125m.yaml
+++ b/examples/llm/yamls/mosaic_gpt/125m.yaml
@@ -79,6 +79,7 @@ algorithms:
 
 max_duration: 4800ba # ~ 2.5B tokens
 eval_interval: 500ba
+eval_first: false
 eval_subset_num_batches: -1
 global_train_batch_size: 256
 

--- a/examples/llm/yamls/mosaic_gpt/125m.yaml
+++ b/examples/llm/yamls/mosaic_gpt/125m.yaml
@@ -18,10 +18,6 @@ model:
   mlp_ratio: 4
   max_seq_len: ${max_seq_len}
   vocab_size: 50368
-  init_std: 0.02
-  attn_pdrop: 0.0
-  resid_pdrop: 0.0
-  emb_pdrop: 0.0
   attn_impl: triton
 
 # Tokenizer

--- a/examples/llm/yamls/mosaic_gpt/125m.yaml
+++ b/examples/llm/yamls/mosaic_gpt/125m.yaml
@@ -92,7 +92,7 @@ precision: amp_bf16
 # FSDP
 fsdp_config:
   sharding_strategy: FULL_SHARD
-  mixed_precision: DEFAULT
+  mixed_precision: PURE
   activation_checkpointing: false
   activation_cpu_offload: false
   verbose: false

--- a/examples/llm/yamls/mosaic_gpt/13b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/13b.yaml
@@ -79,6 +79,7 @@ algorithms:
 
 max_duration: 124000ba # ~ 270B tokens
 eval_interval: 5000ba
+eval_first: false
 eval_subset_num_batches: -1
 global_train_batch_size: 1024
 

--- a/examples/llm/yamls/mosaic_gpt/13b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/13b.yaml
@@ -22,7 +22,7 @@ model:
   attn_pdrop: 0.0
   resid_pdrop: 0.0
   emb_pdrop: 0.0
-  attn_impl: flash
+  attn_impl: triton
 
 # Tokenizer
 tokenizer:

--- a/examples/llm/yamls/mosaic_gpt/13b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/13b.yaml
@@ -92,7 +92,7 @@ precision: amp_bf16
 # FSDP
 fsdp_config:
   sharding_strategy: FULL_SHARD
-  mixed_precision: DEFAULT
+  mixed_precision: PURE
   activation_checkpointing: true
   activation_cpu_offload: false
   verbose: false

--- a/examples/llm/yamls/mosaic_gpt/13b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/13b.yaml
@@ -18,10 +18,6 @@ model:
   mlp_ratio: 4
   max_seq_len: ${max_seq_len}
   vocab_size: 50368
-  init_std: 0.02
-  attn_pdrop: 0.0
-  resid_pdrop: 0.0
-  emb_pdrop: 0.0
   attn_impl: triton
 
 # Tokenizer

--- a/examples/llm/yamls/mosaic_gpt/13b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/13b.yaml
@@ -94,7 +94,9 @@ fsdp_config:
   sharding_strategy: FULL_SHARD
   mixed_precision: PURE
   activation_checkpointing: true
+  activation_checkpointing_reentrant: false
   activation_cpu_offload: false
+  limit_all_gathers: true
   verbose: false
 
 # Logging

--- a/examples/llm/yamls/mosaic_gpt/1b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/1b.yaml
@@ -22,7 +22,7 @@ model:
   attn_pdrop: 0.0
   resid_pdrop: 0.0
   emb_pdrop: 0.0
-  attn_impl: flash
+  attn_impl: triton
 
 # Tokenizer
 tokenizer:

--- a/examples/llm/yamls/mosaic_gpt/1b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/1b.yaml
@@ -94,7 +94,9 @@ fsdp_config:
   sharding_strategy: FULL_SHARD
   mixed_precision: PURE
   activation_checkpointing: false
+  activation_checkpointing_reentrant: false
   activation_cpu_offload: false
+  limit_all_gathers: true
   verbose: false
 
 # Logging

--- a/examples/llm/yamls/mosaic_gpt/1b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/1b.yaml
@@ -18,7 +18,6 @@ model:
   mlp_ratio: 4
   max_seq_len: ${max_seq_len}
   vocab_size: 50368
-
   attn_impl: triton
 
 # Tokenizer

--- a/examples/llm/yamls/mosaic_gpt/1b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/1b.yaml
@@ -18,10 +18,7 @@ model:
   mlp_ratio: 4
   max_seq_len: ${max_seq_len}
   vocab_size: 50368
-  init_std: 0.02
-  attn_pdrop: 0.0
-  resid_pdrop: 0.0
-  emb_pdrop: 0.0
+
   attn_impl: triton
 
 # Tokenizer

--- a/examples/llm/yamls/mosaic_gpt/1b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/1b.yaml
@@ -79,6 +79,7 @@ algorithms:
 
 max_duration: 24800ba # ~ 26B tokens
 eval_interval: 2000ba
+eval_first: false
 eval_subset_num_batches: -1
 global_train_batch_size: 512
 

--- a/examples/llm/yamls/mosaic_gpt/1b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/1b.yaml
@@ -92,7 +92,7 @@ precision: amp_bf16
 # FSDP
 fsdp_config:
   sharding_strategy: FULL_SHARD
-  mixed_precision: DEFAULT
+  mixed_precision: PURE
   activation_checkpointing: false
   activation_cpu_offload: false
   verbose: false

--- a/examples/llm/yamls/mosaic_gpt/30b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/30b.yaml
@@ -22,7 +22,7 @@ model:
   attn_pdrop: 0.0
   resid_pdrop: 0.0
   emb_pdrop: 0.0
-  attn_impl: flash
+  attn_impl: triton
 
 # Tokenizer
 tokenizer:

--- a/examples/llm/yamls/mosaic_gpt/30b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/30b.yaml
@@ -79,6 +79,7 @@ algorithms:
 
 max_duration: 143100ba # ~ 600B tokens
 eval_interval: 10000ba
+eval_first: false
 eval_subset_num_batches: -1
 global_train_batch_size: 2048
 

--- a/examples/llm/yamls/mosaic_gpt/30b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/30b.yaml
@@ -18,10 +18,6 @@ model:
   mlp_ratio: 4
   max_seq_len: ${max_seq_len}
   vocab_size: 50368
-  init_std: 0.02
-  attn_pdrop: 0.0
-  resid_pdrop: 0.0
-  emb_pdrop: 0.0
   attn_impl: triton
 
 # Tokenizer

--- a/examples/llm/yamls/mosaic_gpt/30b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/30b.yaml
@@ -92,9 +92,11 @@ precision: amp_bf16
 # FSDP
 fsdp_config:
   sharding_strategy: FULL_SHARD
-  mixed_precision: PURE # Only needed for 40GB cards
+  mixed_precision: PURE
   activation_checkpointing: true
+  activation_checkpointing_reentrant: false
   activation_cpu_offload: false
+  limit_all_gathers: true
   verbose: false
 
 # Logging

--- a/examples/llm/yamls/mosaic_gpt/350m.yaml
+++ b/examples/llm/yamls/mosaic_gpt/350m.yaml
@@ -22,7 +22,7 @@ model:
   attn_pdrop: 0.0
   resid_pdrop: 0.0
   emb_pdrop: 0.0
-  attn_impl: flash
+  attn_impl: triton
 
 # Tokenizer
 tokenizer:

--- a/examples/llm/yamls/mosaic_gpt/350m.yaml
+++ b/examples/llm/yamls/mosaic_gpt/350m.yaml
@@ -94,7 +94,9 @@ fsdp_config:
   sharding_strategy: FULL_SHARD
   mixed_precision: PURE
   activation_checkpointing: false
+  activation_checkpointing_reentrant: false
   activation_cpu_offload: false
+  limit_all_gathers: true
   verbose: false
 
 # Logging

--- a/examples/llm/yamls/mosaic_gpt/350m.yaml
+++ b/examples/llm/yamls/mosaic_gpt/350m.yaml
@@ -18,10 +18,6 @@ model:
   mlp_ratio: 4
   max_seq_len: ${max_seq_len}
   vocab_size: 50368
-  init_std: 0.02
-  attn_pdrop: 0.0
-  resid_pdrop: 0.0
-  emb_pdrop: 0.0
   attn_impl: triton
 
 # Tokenizer

--- a/examples/llm/yamls/mosaic_gpt/350m.yaml
+++ b/examples/llm/yamls/mosaic_gpt/350m.yaml
@@ -79,6 +79,7 @@ algorithms:
 
 max_duration: 13400ba # ~ 7B tokens
 eval_interval: 1000ba
+eval_first: false
 eval_subset_num_batches: -1
 global_train_batch_size: 256
 

--- a/examples/llm/yamls/mosaic_gpt/350m.yaml
+++ b/examples/llm/yamls/mosaic_gpt/350m.yaml
@@ -92,7 +92,7 @@ precision: amp_bf16
 # FSDP
 fsdp_config:
   sharding_strategy: FULL_SHARD
-  mixed_precision: DEFAULT
+  mixed_precision: PURE
   activation_checkpointing: false
   activation_cpu_offload: false
   verbose: false

--- a/examples/llm/yamls/mosaic_gpt/3b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/3b.yaml
@@ -22,7 +22,7 @@ model:
   attn_pdrop: 0.0
   resid_pdrop: 0.0
   emb_pdrop: 0.0
-  attn_impl: flash
+  attn_impl: triton
 
 # Tokenizer
 tokenizer:

--- a/examples/llm/yamls/mosaic_gpt/3b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/3b.yaml
@@ -92,7 +92,7 @@ precision: amp_bf16
 # FSDP
 fsdp_config:
   sharding_strategy: FULL_SHARD
-  mixed_precision: DEFAULT
+  mixed_precision: PURE
   activation_checkpointing: true
   activation_cpu_offload: false
   verbose: false

--- a/examples/llm/yamls/mosaic_gpt/3b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/3b.yaml
@@ -18,10 +18,6 @@ model:
   mlp_ratio: 4
   max_seq_len: ${max_seq_len}
   vocab_size: 50368
-  init_std: 0.02
-  attn_pdrop: 0.0
-  resid_pdrop: 0.0
-  emb_pdrop: 0.0
   attn_impl: triton
 
 # Tokenizer

--- a/examples/llm/yamls/mosaic_gpt/3b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/3b.yaml
@@ -94,7 +94,9 @@ fsdp_config:
   sharding_strategy: FULL_SHARD
   mixed_precision: PURE
   activation_checkpointing: true
+  activation_checkpointing_reentrant: false
   activation_cpu_offload: false
+  limit_all_gathers: true
   verbose: false
 
 # Logging

--- a/examples/llm/yamls/mosaic_gpt/3b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/3b.yaml
@@ -79,6 +79,7 @@ algorithms:
 
 max_duration: 51500ba # ~ 54B tokens
 eval_interval: 5000ba
+eval_first: false
 eval_subset_num_batches: -1
 global_train_batch_size: 512
 

--- a/examples/llm/yamls/mosaic_gpt/70b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/70b.yaml
@@ -22,7 +22,7 @@ model:
   attn_pdrop: 0.0
   resid_pdrop: 0.0
   emb_pdrop: 0.0
-  attn_impl: flash
+  attn_impl: triton
 
 # Tokenizer
 tokenizer:

--- a/examples/llm/yamls/mosaic_gpt/70b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/70b.yaml
@@ -79,6 +79,7 @@ algorithms:
 
 max_duration: 333800ba  # ~ 1.4T tokens
 eval_interval: 10000ba
+eval_first: false
 eval_subset_num_batches: -1
 global_train_batch_size: 2048
 

--- a/examples/llm/yamls/mosaic_gpt/70b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/70b.yaml
@@ -18,10 +18,6 @@ model:
   mlp_ratio: 4
   max_seq_len: ${max_seq_len}
   vocab_size: 50368
-  init_std: 0.02
-  attn_pdrop: 0.0
-  resid_pdrop: 0.0
-  emb_pdrop: 0.0
   attn_impl: triton
 
 # Tokenizer

--- a/examples/llm/yamls/mosaic_gpt/70b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/70b.yaml
@@ -92,9 +92,11 @@ precision: amp_bf16
 # FSDP
 fsdp_config:
   sharding_strategy: FULL_SHARD
-  mixed_precision: PURE # Only needed for 40GB cards
+  mixed_precision: PURE
   activation_checkpointing: true
+  activation_checkpointing_reentrant: false
   activation_cpu_offload: false
+  limit_all_gathers: true
   verbose: false
 
 # Logging

--- a/examples/llm/yamls/mosaic_gpt/760m.yaml
+++ b/examples/llm/yamls/mosaic_gpt/760m.yaml
@@ -22,7 +22,7 @@ model:
   attn_pdrop: 0.0
   resid_pdrop: 0.0
   emb_pdrop: 0.0
-  attn_impl: flash
+  attn_impl: triton
 
 # Tokenizer
 tokenizer:

--- a/examples/llm/yamls/mosaic_gpt/760m.yaml
+++ b/examples/llm/yamls/mosaic_gpt/760m.yaml
@@ -94,7 +94,9 @@ fsdp_config:
   sharding_strategy: FULL_SHARD
   mixed_precision: PURE
   activation_checkpointing: false
+  activation_checkpointing_reentrant: false
   activation_cpu_offload: false
+  limit_all_gathers: true
   verbose: false
 
 # Logging

--- a/examples/llm/yamls/mosaic_gpt/760m.yaml
+++ b/examples/llm/yamls/mosaic_gpt/760m.yaml
@@ -18,10 +18,6 @@ model:
   mlp_ratio: 4
   max_seq_len: ${max_seq_len}
   vocab_size: 50368
-  init_std: 0.02
-  attn_pdrop: 0.0
-  resid_pdrop: 0.0
-  emb_pdrop: 0.0
   attn_impl: triton
 
 # Tokenizer

--- a/examples/llm/yamls/mosaic_gpt/760m.yaml
+++ b/examples/llm/yamls/mosaic_gpt/760m.yaml
@@ -79,6 +79,7 @@ algorithms:
 
 max_duration: 29000ba # ~ 15.2B tokens
 eval_interval: 2000ba
+eval_first: false
 eval_subset_num_batches: -1
 global_train_batch_size: 256
 

--- a/examples/llm/yamls/mosaic_gpt/760m.yaml
+++ b/examples/llm/yamls/mosaic_gpt/760m.yaml
@@ -92,7 +92,7 @@ precision: amp_bf16
 # FSDP
 fsdp_config:
   sharding_strategy: FULL_SHARD
-  mixed_precision: DEFAULT
+  mixed_precision: PURE
   activation_checkpointing: false
   activation_cpu_offload: false
   verbose: false

--- a/examples/llm/yamls/mosaic_gpt/7b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/7b.yaml
@@ -79,6 +79,7 @@ algorithms:
 
 max_duration: 63900ba # ~ 134B tokens
 eval_interval: 5000ba
+eval_first: false
 eval_subset_num_batches: -1
 global_train_batch_size: 1024
 

--- a/examples/llm/yamls/mosaic_gpt/7b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/7b.yaml
@@ -22,7 +22,7 @@ model:
   attn_pdrop: 0.0
   resid_pdrop: 0.0
   emb_pdrop: 0.0
-  attn_impl: flash
+  attn_impl: triton
 
 # Tokenizer
 tokenizer:

--- a/examples/llm/yamls/mosaic_gpt/7b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/7b.yaml
@@ -92,7 +92,7 @@ precision: amp_bf16
 # FSDP
 fsdp_config:
   sharding_strategy: FULL_SHARD
-  mixed_precision: DEFAULT
+  mixed_precision: PURE
   activation_checkpointing: true
   activation_cpu_offload: false
   verbose: false

--- a/examples/llm/yamls/mosaic_gpt/7b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/7b.yaml
@@ -18,10 +18,6 @@ model:
   mlp_ratio: 4
   max_seq_len: ${max_seq_len}
   vocab_size: 50368
-  init_std: 0.02
-  attn_pdrop: 0.0
-  resid_pdrop: 0.0
-  emb_pdrop: 0.0
   attn_impl: triton
 
 # Tokenizer

--- a/examples/llm/yamls/mosaic_gpt/7b.yaml
+++ b/examples/llm/yamls/mosaic_gpt/7b.yaml
@@ -94,7 +94,9 @@ fsdp_config:
   sharding_strategy: FULL_SHARD
   mixed_precision: PURE
   activation_checkpointing: true
+  activation_checkpointing_reentrant: false
   activation_cpu_offload: false
+  limit_all_gathers: true
   verbose: false
 
 # Logging

--- a/examples/llm/yamls/mosaic_gpt/testing.yaml
+++ b/examples/llm/yamls/mosaic_gpt/testing.yaml
@@ -93,7 +93,7 @@ precision: amp_bf16
 # FSDP
 fsdp_config:
   sharding_strategy: FULL_SHARD
-  mixed_precision: DEFAULT
+  mixed_precision: PURE
   activation_checkpointing: false
   activation_cpu_offload: false
   verbose: false

--- a/examples/llm/yamls/mosaic_gpt/testing.yaml
+++ b/examples/llm/yamls/mosaic_gpt/testing.yaml
@@ -95,7 +95,9 @@ fsdp_config:
   sharding_strategy: FULL_SHARD
   mixed_precision: PURE
   activation_checkpointing: false
+  activation_checkpointing_reentrant: false
   activation_cpu_offload: false
+  limit_all_gathers: true
   verbose: false
 
 # Logging

--- a/examples/llm/yamls/mosaic_gpt/testing.yaml
+++ b/examples/llm/yamls/mosaic_gpt/testing.yaml
@@ -18,10 +18,6 @@ model:
   mlp_ratio: 4
   max_seq_len: ${max_seq_len}
   vocab_size: 50368
-  init_std: 0.02
-  attn_pdrop: 0.0
-  resid_pdrop: 0.0
-  emb_pdrop: 0.0
   attn_impl: torch
   loss_fn: torch_crossentropy
 

--- a/examples/llm/yamls/mosaic_gpt/testing.yaml
+++ b/examples/llm/yamls/mosaic_gpt/testing.yaml
@@ -80,6 +80,7 @@ algorithms:
 
 max_duration: 200ba
 eval_interval: 100ba
+eval_first: false
 eval_subset_num_batches: -1
 global_train_batch_size: 256
 


### PR DESCRIPTION
FSDP new defaults:
* mixed_precision: PURE
* activation_checkpointing_reentrant: false
* limit_all_gathers: true

MosaicGPT new defaults:
* attn_impl='triton'
* param_init_fn='kaiming_normal_'
* init_nonlinearity='relu'
* low_precision_layernorm=True

Training loop new defaults
* `eval_first: false` just to expose that this an option 