### PR TITLE
updt throughput tables

### DIFF
--- a/examples/common/builders.py
+++ b/examples/common/builders.py
@@ -17,9 +17,11 @@ from composer.optim.scheduler import (ConstantWithWarmupScheduler,
                                       LinearWithWarmupScheduler)
 
 from examples.common.fdiff import FDiffMetrics
-from examples.common.optim import DecoupledLionW, DecoupledClipLion, DecoupledAdaLRLion
-from examples.common.text_data import build_text_dataloader
+from examples.common.generate_callback import Generate
+from examples.common.optim import (DecoupledAdaLRLion, DecoupledClipLion,
+                                   DecoupledLionW)
 from examples.common.resumption_callbacks import GlobalLRScaling, LayerFreezing
+from examples.common.text_data import build_text_dataloader
 
 
 def build_callback(name, kwargs):
@@ -40,6 +42,9 @@ def build_callback(name, kwargs):
             'log_optimizer_metrics', True),)
     elif name == 'health_checker':
         return HealthChecker(**kwargs)
+    elif name == 'generate_callback':
+        prompts = kwargs.pop('prompts')
+        return Generate(prompts=list(prompts), **kwargs)
     elif name == 'global_lr_scaling':
         return GlobalLRScaling(**kwargs)
     elif name == 'layer_freezing':
@@ -84,19 +89,19 @@ def build_optimizer(cfg, model):
                               weight_decay=cfg.weight_decay)
     elif cfg.name == 'clip_lion':
         return DecoupledClipLion(model.parameters(),
-                        lr=cfg.lr,
-                        betas=cfg.betas,
-                        weight_decay=cfg.weight_decay,
-                        outlier_threshold=cfg.outlier_threshold)
+                                 lr=cfg.lr,
+                                 betas=cfg.betas,
+                                 weight_decay=cfg.weight_decay,
+                                 outlier_threshold=cfg.outlier_threshold)
     elif cfg.name == 'adalr_lion':
         return DecoupledAdaLRLion(model.parameters(),
-                         lr=cfg.lr,
-                         betas=cfg.betas,
-                         weight_decay=cfg.weight_decay,
-                         outlier_threshold=cfg.outlier_threshold,
-                         timeout=cfg.timeout,
-                         lr_penalty=cfg.lr_penalty,
-                         min_scale=cfg.min_scale)
+                                  lr=cfg.lr,
+                                  betas=cfg.betas,
+                                  weight_decay=cfg.weight_decay,
+                                  outlier_threshold=cfg.outlier_threshold,
+                                  timeout=cfg.timeout,
+                                  lr_penalty=cfg.lr_penalty,
+                                  min_scale=cfg.min_scale)
     else:
         raise ValueError(f'Not sure how to build optimizer: {cfg.name}')
 

--- a/examples/common/generate_callback.py
+++ b/examples/common/generate_callback.py
@@ -1,0 +1,93 @@
+# Copyright 2022 MosaicML Examples authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Periodically log generations to wandb from a set of prompts."""
+from typing import List
+
+import wandb
+from composer.core import Callback, State
+from composer.loggers import Logger, WandBLogger
+from composer.utils import dist, ensure_tuple
+
+
+class Generate(Callback):
+
+    def __init__(self, prompts: List[str], **kwargs):
+        """Periodically log generations to wandb from a set of prompts.
+
+        In the main view for a run, there will be a table that will show the _last_ logged generations.
+        To compare previous iterations of the generations, you need to
+        1. Click on the run
+        2. Click on "artifacts" in the menu on the left side of the screen
+        3. Click on one of the artifacts called "predictions"
+        4. Click on the "files" tab
+        5. Click on "predictions.table.json"
+        6. On the left hand side, there are different versions of the table produced throughout training. Select one of these.
+        7. Now, when you hover over other versions, there will be a "compare" button, which will allow you to compare the currently
+            selected version to the version you add via compare.
+
+        Args:
+            prompts (List[str]): The list of prompts you would like to produce generations for
+            kwargs: All kwargs well be passed along to the call to generate. This is for things like `do_sample`, `top_p`, etc
+        """
+        self.prompts = prompts
+        self.generate_kwargs = kwargs
+        self.wandb_logger = None
+
+    def init(self, state: State, logger: Logger):
+        if dist.get_global_rank() == 0:
+            for destination in ensure_tuple(logger.destinations):
+                if isinstance(destination, WandBLogger):
+                    self.wandb_logger = destination
+
+    def eval_end(self, state: State, logger: Logger):
+        model = state.model
+        tokenizer = state.model.tokenizer
+        device = state.device
+
+        # stash the original original value of padding_side because generation requires left padding
+        original_padding_side = tokenizer.padding_side
+        tokenizer.padding_side = 'left'
+        if tokenizer.pad_token_id is None:
+            tokenizer.pad_token_id = tokenizer.eos_token_id
+        tokenized_input = tokenizer(self.prompts,
+                                    return_tensors='pt',
+                                    padding=True)
+
+        for k, v in tokenized_input.items():
+            tokenized_input[k] = device.tensor_to_device(v)
+
+        output_token_ids = model.model.generate(
+            input_ids=tokenized_input['input_ids'],
+            attention_mask=tokenized_input['attention_mask'],
+            synced_gpus=True,
+            **self.generate_kwargs,
+        )
+
+        if dist.get_global_rank() == 0:
+            if self.wandb_logger is not None:
+                artifact = wandb.Artifact('generate_samples_' +
+                                          str(wandb.run.id),
+                                          type='predictions')
+
+                rows = []
+                for i in range(len(self.prompts)):
+                    prompt = self.prompts[i]
+                    output_tokens = output_token_ids[i][
+                        tokenized_input['input_ids'].shape[1]:]
+                    output_text = tokenizer.decode(output_tokens,
+                                                   skip_special_tokens=True)
+
+                    rows.append([prompt, output_text])
+
+                text_table = wandb.Table(data=rows,
+                                         columns=['prompt', 'generation'])
+                artifact.add(text_table, 'predictions')
+                wandb.log_artifact(artifact)
+                wandb.log({'generations': text_table},
+                          step=state.timestamp.batch.value)
+
+        tokenizer.padding_side = original_padding_side

--- a/examples/llm/throughput/README.md
+++ b/examples/llm/throughput/README.md
@@ -1,3 +1,174 @@
+# MosaicGPT Training Benchmarks
+
+Benchmark measurements for MosaicGPT models trained on [MosaicML platform](https://www.mosaicml.com/platform), including throughput, MFU, and HFU. Each model is based on optimized configurations of various sizes in the [yamls](../yamls) folder, ranging from a 125m to 70B parameter models.
+
+To reproduce these results, first:
+```
+python submit_benchmarks.py --cluster [your_mosaicml_cluster] ARGS --RUN
+```
+
+will use our Python API to submit a sweep of the specified configurations.
+
+Then, after the runs are completed:
+```
+python collect_results.py --save-path results
+```
+will use our Python API to collect and calculate the benchmark results, and then save as both a CSV file `results.csv`, and a markdown table `results.md`.
+
+> **Note**
+> The `collect_results.py` will by default find all runs with `tput` in the run name. To customize this project tag, use `--project` in both the submissing and collection scripts.
+
+
+## MFU and HFU
+
+Model FLOPs Utilization (MFU) and Hardware FLOPS Utilization (HFU) are estimates, based on the throughput and the known FLOPs of the computation, of what percentage of the hardware's FLOPs are being used during training.
+
+MFU calculates the utilizaiton from the floating point operations required for a single forward/backwards pass of the model, and do not account for the additional compute required for other implementation details such as activation checkpointing. Thus, MFU is independant of implementation and hardware.
+
+HFU attempt to capture the actual floating point operations incurred during the forward/backwards pass on the hardware, and is a more accurate measurement of hardware utilization, but less general and difficult to compare across various hardware and implementation details.
+
+For more information, see [Korthikanti et al, 2022](https://arxiv.org/abs/2205.05198). All FLOP calculations exclude the operations required for normalization, activation, and residuals.
+
+### MFU
+
+Per token, each parameter is used for a MAC (2 FLOPS) per network operation. Neural Network training has 3 network operations: forward pass, backward pass, and computation of parameter gradient.
+
+The attention mechanism forward pass FLOPS are: `attn_flops_per_seq = n_layers * 2 * 2 * (d_model * (seq_len**2))`
+```
+flops_per_token = 2 * n_params
+flops_per_seq = flops_per_token * seq_len
+mfu* = 3 * flops_per_seq * throughput / (gpu_num * GPU_AVAILABLE_FLOPS)
+
+attn_flops_per_seq = n_layers * 2 * 2 * (d_model * (seq_len**2))
+mfu = (3 * flops_per_seq + 3 * attn_flops_per_seq) * throughput / (gpu_num * GPU_AVAILABLE_FLOPS)
+```
+
+### HFU
+
+The HFU numbers shown below account for the fact that the networks use checkpointing and recomputes activations. This effectively requires an extra forward pass through the network.
+```
+hfu* = 4 * flops_per_seq * throughput / (gpu_num * GPU_AVAILABLE_FLOPS)
+hfu = (4 * flops_per_seq + 4 * attn_flops_per_seq) * throughput / (gpu_num * GPU_AVAILABLE_FLOPS)
+```
+
+Note that these are approximations. Actual HFU would be higher since it includes the floating point operations for normalization, activation, and residual lyaers, as well as **all** recomputation. For example, our models use Flash Attention, which requires including an extra recompute factor for its recomputation in the forward pass. Therefore, the attention multipler would be 5 instead of 4.
+
+## Results
+
+Below we include several configurations across different hardware platforms, sequence lengths and batch sizes. It is easy to benchmark configurations for your own use case. For example, using Mosaic Cloud, to test MosaicGPT {13B, 30B} using fp16 with a batch size of 2M tokens and seq len {2k, 4k, 8k, 16k} run:
+```
+python submit_benchmarks.py -m 13b.yaml 30b.yaml -t fp16 -b 21 21 -s 11 14 --RUN
+```
+This will run 8 configs for 12 steps to get throughput numbers. `python collect_results.py` can then be used to parse all output training logs and create the tables below.
+
+Sometimes we report Global Batchsizes that are not evenly divisible by the micro batch size. Our microbatching engine allows for non-divisible sizes, while being mathematically faithful to the global batch size. For example, a total batch size of 48, and a micro batch of 11, means we will accumulate gradients across microbatches of 11, 11, 11, 11, 4.
+
+#### TODO: Updated using torch 2.0
+
+## A100 80GB
+
+|  Model | SeqLen (T) | # GPUs | GPU | MFU | HFU | MicroBatchSize | GradAccum | GlobalBatchSize | Throughput (S/s) | Throughput (T/s) | Throughput (T/s/GPU) | GlobalBatchSize (T) | Precision | MP Mode | Sharding Strategy | Activation Checkpointing | Activation CPUOffload | NumParams |
+|  --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+|  70b | 2048 | 64 | a100_80gb | 53.33 | 71.1 | 8 | 4 | 2048 | 12 | 26274 | 410 | 4194304 | bf16 | PURE | FULL_SHARD | True | False | 64862437376 |
+|  70b | 2048 | 32 | a100_80gb | 48.56 | 64.75 | 2 | 16 | 1024 | 5 | 11962 | 373 | 2097152 | bf16 | PURE | FULL_SHARD | True | False | 64862437376 |
+|  30b | 8192 | 8 | a100_80gb | 42.66 | 56.89 | 1 | 21 | 168 | 0 | 4977 | 622 | 1376256 | bf16 | PURE | FULL_SHARD | True | False | 30019254272 |
+|  30b | 4096 | 8 | a100_80gb | 49.12 | 65.49 | 1 | 21 | 168 | 1 | 6227 | 778 | 688128 | bf16 | PURE | FULL_SHARD | True | False | 29989894144 |
+|  30b | 2048 | 64 | a100_80gb | 52.93 | 70.57 | 16 | 3 | 3072 | 27 | 56126 | 876 | 6291456 | bf16 | PURE | FULL_SHARD | True | False | 29975214080 |
+|  30b | 2048 | 32 | a100_80gb | 53.48 | 71.3 | 14 | 3 | 1344 | 13 | 28353 | 886 | 2752512 | bf16 | PURE | FULL_SHARD | True | False | 29975214080 |
+|  30b | 2048 | 16 | a100_80gb | 53.4 | 71.2 | 10 | 3 | 480 | 6 | 14157 | 884 | 983040 | bf16 | PURE | FULL_SHARD | True | False | 29975214080 |
+|  30b | 2048 | 8 | a100_80gb | 47.57 | 63.43 | 3 | 21 | 504 | 3 | 6305 | 788 | 1032192 | bf16 | PURE | FULL_SHARD | True | False | 29975214080 |
+|  30b | 1024 | 8 | a100_80gb | 51.69 | 68.92 | 6 | 21 | 1008 | 6 | 7010 | 876 | 1032192 | bf16 | PURE | FULL_SHARD | True | False | 29967874048 |
+|  30b | 512 | 8 | a100_80gb | 49.23 | 65.63 | 12 | 21 | 2016 | 13 | 6754 | 844 | 1032192 | bf16 | PURE | FULL_SHARD | True | False | 29964204032 |
+|  13b | 32768 | 8 | a100_80gb | 49.53 | 66.04 | 1 | 3 | 24 | 0 | 7795 | 974 | 786432 | bf16 | PURE | FULL_SHARD | True | False | 13011240960 |
+|  13b | 16384 | 8 | a100_80gb | 51.71 | 68.94 | 3 | 3 | 72 | 0 | 10953 | 1369 | 1179648 | bf16 | PURE | FULL_SHARD | True | False | 12927354880 |
+|  13b | 8192 | 8 | a100_80gb | 52.83 | 70.44 | 5 | 3 | 120 | 1 | 13531 | 1691 | 983040 | bf16 | PURE | FULL_SHARD | True | False | 12885411840 |
+|  13b | 4096 | 8 | a100_80gb | 53.62 | 71.5 | 10 | 3 | 240 | 3 | 15339 | 1917 | 983040 | bf16 | PURE | FULL_SHARD | True | False | 12864440320 |
+|  13b | 2048 | 64 | a100_80gb | 52.51 | 70.01 | 32 | 1 | 2048 | 62 | 127624 | 1994 | 4194304 | bf16 | PURE | FULL_SHARD | True | False | 12853954560 |
+|  13b | 2048 | 32 | a100_80gb | 52.86 | 70.48 | 32 | 1 | 1024 | 31 | 64241 | 2007 | 2097152 | bf16 | PURE | FULL_SHARD | True | False | 12853954560 |
+|  13b | 2048 | 16 | a100_80gb | 53.14 | 70.86 | 24 | 1 | 384 | 15 | 32291 | 2018 | 786432 | bf16 | PURE | FULL_SHARD | True | False | 12853954560 |
+|  13b | 2048 | 8 | a100_80gb | 54.38 | 72.51 | 20 | 3 | 480 | 8 | 16522 | 2065 | 983040 | bf16 | PURE | FULL_SHARD | True | False | 12853954560 |
+|  13b | 1024 | 8 | a100_80gb | 55.23 | 73.63 | 40 | 3 | 960 | 16 | 17315 | 2164 | 983040 | bf16 | PURE | FULL_SHARD | True | False | 12848711680 |
+|  13b | 512 | 8 | a100_80gb | 54.99 | 73.32 | 80 | 3 | 1920 | 34 | 17521 | 2190 | 983040 | bf16 | PURE | FULL_SHARD | True | False | 12846090240 |
+|  7b | 65536 | 8 | a100_80gb | 42.61 | 56.82 | 1 | 2 | 16 | 0 | 7355 | 919 | 1048576 | bf16 | PURE | FULL_SHARD | True | False | 6918905856 |
+|  7b | 32768 | 8 | a100_80gb | 48.18 | 64.24 | 2 | 2 | 32 | 0 | 13035 | 1629 | 1048576 | bf16 | PURE | FULL_SHARD | True | False | 6784688128 |
+|  7b | 16384 | 8 | a100_80gb | 49.5 | 66.0 | 4 | 2 | 64 | 1 | 18698 | 2337 | 1048576 | bf16 | PURE | FULL_SHARD | True | False | 6717579264 |
+|  7b | 8192 | 8 | a100_80gb | 50.71 | 67.62 | 8 | 2 | 128 | 2 | 23887 | 2985 | 1048576 | bf16 | PURE | FULL_SHARD | True | False | 6684024832 |
+|  7b | 4096 | 8 | a100_80gb | 52.05 | 69.4 | 16 | 2 | 256 | 6 | 27973 | 3496 | 1048576 | bf16 | PURE | FULL_SHARD | True | False | 6667247616 |
+|  7b | 2048 | 64 | a100_80gb | 50.8 | 67.73 | 32 | 1 | 2048 | 114 | 234932 | 3670 | 4194304 | bf16 | PURE | FULL_SHARD | True | False | 6658859008 |
+|  7b | 2048 | 32 | a100_80gb | 51.16 | 68.22 | 32 | 1 | 1024 | 57 | 118310 | 3697 | 2097152 | bf16 | PURE | FULL_SHARD | True | False | 6658859008 |
+|  7b | 2048 | 16 | a100_80gb | 51.59 | 68.79 | 32 | 1 | 512 | 29 | 59653 | 3728 | 1048576 | bf16 | PURE | FULL_SHARD | True | False | 6658859008 |
+|  7b | 2048 | 8 | a100_80gb | 52.92 | 70.56 | 32 | 2 | 512 | 14 | 30596 | 3824 | 1048576 | bf16 | PURE | FULL_SHARD | True | False | 6658859008 |
+|  7b | 1024 | 8 | a100_80gb | 53.66 | 71.55 | 64 | 2 | 1024 | 31 | 32243 | 4030 | 1048576 | bf16 | PURE | FULL_SHARD | True | False | 6654664704 |
+|  7b | 512 | 8 | a100_80gb | 53.5 | 71.34 | 128 | 2 | 2048 | 64 | 32794 | 4099 | 1048576 | bf16 | PURE | FULL_SHARD | True | False | 6652567552 |
+|  3b | 65536 | 8 | a100_80gb | 46.17 | 61.57 | 1 | 2 | 16 | 0 | 14174 | 1771 | 1048576 | bf16 | PURE | FULL_SHARD | True | False | 2814366720 |
+|  3b | 32768 | 8 | a100_80gb | 46.73 | 62.31 | 3 | 6 | 144 | 0 | 24003 | 3000 | 4718592 | bf16 | PURE | FULL_SHARD | True | False | 2730480640 |
+|  3b | 16384 | 8 | a100_80gb | 57.29 | 57.29 | 1 | 6 | 48 | 2 | 44356 | 5544 | 786432 | bf16 | PURE | FULL_SHARD | False | False | 2688537600 |
+|  3b | 8192 | 8 | a100_80gb | 58.68 | 58.68 | 3 | 6 | 144 | 7 | 60883 | 7610 | 1179648 | bf16 | PURE | FULL_SHARD | False | False | 2667566080 |
+|  3b | 4096 | 8 | a100_80gb | 59.51 | 59.51 | 5 | 6 | 240 | 18 | 74388 | 9298 | 983040 | bf16 | PURE | FULL_SHARD | False | False | 2657080320 |
+|  3b | 2048 | 64 | a100_80gb | 58.36 | 58.36 | 12 | 3 | 2304 | 317 | 650175 | 10158 | 4718592 | bf16 | PURE | FULL_SHARD | False | False | 2651837440 |
+|  3b | 2048 | 32 | a100_80gb | 59.22 | 59.22 | 12 | 3 | 1152 | 161 | 329856 | 10308 | 2359296 | bf16 | PURE | FULL_SHARD | False | False | 2651837440 |
+|  3b | 2048 | 16 | a100_80gb | 59.08 | 59.08 | 10 | 3 | 480 | 80 | 164543 | 10283 | 983040 | bf16 | PURE | FULL_SHARD | False | False | 2651837440 |
+|  3b | 2048 | 8 | a100_80gb | 59.77 | 59.77 | 10 | 6 | 480 | 40 | 83230 | 10403 | 983040 | bf16 | PURE | FULL_SHARD | False | False | 2651837440 |
+|  3b | 1024 | 8 | a100_80gb | 61.56 | 61.56 | 20 | 6 | 960 | 88 | 90906 | 11363 | 983040 | bf16 | PURE | FULL_SHARD | False | False | 2649216000 |
+|  3b | 512 | 8 | a100_80gb | 62.09 | 62.09 | 40 | 6 | 1920 | 184 | 94553 | 11819 | 983040 | bf16 | PURE | FULL_SHARD | False | False | 2647905280 |
+|  1b | 65536 | 8 | a100_80gb | 45.29 | 60.39 | 1 | 2 | 16 | 0 | 23885 | 2985 | 1048576 | bf16 | PURE | FULL_SHARD | True | False | 1445974016 |
+|  1b | 32768 | 8 | a100_80gb | 56.02 | 56.02 | 1 | 4 | 32 | 1 | 50657 | 6332 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 1378865152 |
+|  1b | 16384 | 8 | a100_80gb | 55.84 | 55.84 | 2 | 4 | 64 | 4 | 78591 | 9823 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 1345310720 |
+|  1b | 8192 | 8 | a100_80gb | 56.38 | 56.38 | 3 | 4 | 96 | 13 | 109915 | 13739 | 786432 | bf16 | PURE | FULL_SHARD | False | False | 1328533504 |
+|  1b | 4096 | 8 | a100_80gb | 58.3 | 58.3 | 7 | 4 | 224 | 34 | 140767 | 17595 | 917504 | bf16 | PURE | FULL_SHARD | False | False | 1320144896 |
+|  1b | 2048 | 64 | a100_80gb | 56.67 | 56.67 | 20 | 1 | 1280 | 606 | 1243103 | 19423 | 2621440 | bf16 | PURE | FULL_SHARD | False | False | 1315950592 |
+|  1b | 2048 | 32 | a100_80gb | 56.74 | 56.74 | 20 | 1 | 640 | 303 | 622285 | 19446 | 1310720 | bf16 | PURE | FULL_SHARD | False | False | 1315950592 |
+|  1b | 2048 | 16 | a100_80gb | 57.47 | 57.47 | 20 | 1 | 320 | 153 | 315117 | 19694 | 655360 | bf16 | PURE | FULL_SHARD | False | False | 1315950592 |
+|  1b | 2048 | 8 | a100_80gb | 59.16 | 59.16 | 14 | 4 | 448 | 79 | 162214 | 20276 | 917504 | bf16 | PURE | FULL_SHARD | False | False | 1315950592 |
+|  1b | 1024 | 8 | a100_80gb | 58.98 | 58.98 | 18 | 4 | 576 | 169 | 173458 | 21682 | 589824 | bf16 | PURE | FULL_SHARD | False | False | 1313853440 |
+|  1b | 512 | 8 | a100_80gb | 60.38 | 60.38 | 56 | 4 | 1792 | 359 | 184268 | 23033 | 917504 | bf16 | PURE | FULL_SHARD | False | False | 1312804864 |
+|  760m | 65536 | 8 | a100_80gb | 45.48 | 60.64 | 1 | 2 | 16 | 0 | 33252 | 4156 | 1048576 | bf16 | PURE | FULL_SHARD | True | False | 857988096 |
+|  760m | 32768 | 8 | a100_80gb | 54.48 | 54.48 | 1 | 2 | 16 | 2 | 70305 | 8788 | 524288 | bf16 | PURE | FULL_SHARD | False | False | 807656448 |
+|  760m | 16384 | 8 | a100_80gb | 55.21 | 55.21 | 3 | 2 | 48 | 7 | 115383 | 14422 | 786432 | bf16 | PURE | FULL_SHARD | False | False | 782490624 |
+|  760m | 8192 | 8 | a100_80gb | 55.13 | 55.13 | 6 | 2 | 96 | 20 | 166928 | 20866 | 786432 | bf16 | PURE | FULL_SHARD | False | False | 769907712 |
+|  760m | 4096 | 8 | a100_80gb | 55.2 | 55.2 | 12 | 2 | 192 | 52 | 215501 | 26937 | 786432 | bf16 | PURE | FULL_SHARD | False | False | 763616256 |
+|  760m | 2048 | 64 | a100_80gb | 51.82 | 51.82 | 24 | 1 | 1536 | 923 | 1892166 | 29565 | 3145728 | bf16 | PURE | FULL_SHARD | False | False | 760470528 |
+|  760m | 2048 | 32 | a100_80gb | 53.27 | 53.27 | 24 | 1 | 768 | 474 | 972497 | 30390 | 1572864 | bf16 | PURE | FULL_SHARD | False | False | 760470528 |
+|  760m | 2048 | 16 | a100_80gb | 53.56 | 53.56 | 24 | 1 | 384 | 238 | 488871 | 30554 | 786432 | bf16 | PURE | FULL_SHARD | False | False | 760470528 |
+|  760m | 2048 | 8 | a100_80gb | 55.67 | 55.67 | 24 | 2 | 384 | 124 | 254104 | 31763 | 786432 | bf16 | PURE | FULL_SHARD | False | False | 760470528 |
+|  760m | 1024 | 8 | a100_80gb | 55.98 | 55.98 | 48 | 2 | 768 | 272 | 279108 | 34888 | 786432 | bf16 | PURE | FULL_SHARD | False | False | 758897664 |
+|  760m | 512 | 8 | a100_80gb | 56.2 | 56.2 | 96 | 2 | 1536 | 573 | 293755 | 36719 | 786432 | bf16 | PURE | FULL_SHARD | False | False | 758111232 |
+|  350m | 65536 | 8 | a100_80gb | 52.39 | 52.39 | 1 | 2 | 16 | 0 | 59835 | 7479 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 420997120 |
+|  350m | 32768 | 8 | a100_80gb | 47.45 | 47.45 | 2 | 2 | 32 | 3 | 98793 | 12349 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 387442688 |
+|  350m | 16384 | 8 | a100_80gb | 53.01 | 53.01 | 4 | 2 | 64 | 11 | 187535 | 23441 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 370665472 |
+|  350m | 8192 | 8 | a100_80gb | 53.21 | 53.21 | 8 | 2 | 128 | 35 | 289398 | 36174 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 362276864 |
+|  350m | 4096 | 8 | a100_80gb | 52.46 | 52.46 | 16 | 2 | 256 | 95 | 390131 | 48766 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 358082560 |
+|  350m | 2048 | 64 | a100_80gb | 47.76 | 47.76 | 32 | 1 | 2048 | 1699 | 3480601 | 54384 | 4194304 | bf16 | PURE | FULL_SHARD | False | False | 355985408 |
+|  350m | 2048 | 32 | a100_80gb | 48.58 | 48.58 | 32 | 1 | 1024 | 864 | 1770287 | 55321 | 2097152 | bf16 | PURE | FULL_SHARD | False | False | 355985408 |
+|  350m | 2048 | 16 | a100_80gb | 50.53 | 50.53 | 32 | 1 | 512 | 449 | 920605 | 57537 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 355985408 |
+|  350m | 2048 | 8 | a100_80gb | 51.73 | 51.73 | 32 | 2 | 512 | 230 | 471290 | 58911 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 355985408 |
+|  350m | 1024 | 8 | a100_80gb | 51.28 | 51.28 | 64 | 2 | 1024 | 514 | 526393 | 65799 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 354936832 |
+|  350m | 512 | 8 | a100_80gb | 51.18 | 51.18 | 128 | 2 | 2048 | 1095 | 560858 | 70107 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 354412544 |
+|  125m | 65536 | 8 | a100_80gb | 54.31 | 54.31 | 1 | 2 | 16 | 2 | 163472 | 20434 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 174070272 |
+|  125m | 32768 | 8 | a100_80gb | 53.15 | 53.15 | 2 | 2 | 32 | 8 | 293685 | 36710 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 148904448 |
+|  125m | 16384 | 8 | a100_80gb | 51.58 | 51.58 | 4 | 2 | 64 | 29 | 489578 | 61197 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 136321536 |
+|  125m | 8192 | 8 | a100_80gb | 49.18 | 49.18 | 8 | 2 | 128 | 88 | 727986 | 90998 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 130030080 |
+|  125m | 4096 | 8 | a100_80gb | 46.62 | 46.62 | 16 | 2 | 256 | 233 | 958343 | 119792 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 126884352 |
+|  125m | 2048 | 64 | a100_80gb | 40.77 | 40.77 | 32 | 1 | 2048 | 4063 | 8321727 | 130026 | 4194304 | bf16 | PURE | FULL_SHARD | False | False | 125311488 |
+|  125m | 2048 | 32 | a100_80gb | 41.22 | 41.22 | 32 | 1 | 1024 | 2053 | 4206041 | 131438 | 2097152 | bf16 | PURE | FULL_SHARD | False | False | 125311488 |
+|  125m | 2048 | 16 | a100_80gb | 41.92 | 41.92 | 32 | 1 | 512 | 1044 | 2139036 | 133689 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 125311488 |
+|  125m | 2048 | 8 | a100_80gb | 44.04 | 44.04 | 32 | 2 | 512 | 548 | 1123506 | 140438 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 125311488 |
+|  125m | 1024 | 8 | a100_80gb | 43.25 | 43.25 | 64 | 2 | 1024 | 1225 | 1254561 | 156820 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 124525056 |
+|  125m | 512 | 8 | a100_80gb | 42.54 | 42.54 | 128 | 2 | 2048 | 2587 | 1325030 | 165628 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 124131840 |
+
+
+
+
+
+
+
+
+
+
+<!-- 
+
+
+
 ## Warning: Some of the numbers below, particularly for 30B and 70B models, are out of date. The current repo achieves higher throughput / MFU. This warning will be removed once the tables are updated.
 
 # MosaicGPT Training Benchmarks
@@ -229,4 +400,4 @@ The <30B measurements below reflect the latest version of our codebase:
 | gpt125m | 2048       | 64      | a100_40gb | 30.23 | 30.23 | 2048            | 16             | 2         | 3014             | 6172908          | 96452                | 4194304             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760  |
 | gpt125m | 2048       | 64      | a100_40gb | 29.67 | 29.67 | 1024            | 16             | 1         | 2958             | 6059175          | 94674                | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760  |
 | gpt125m | 2048       | 64      | a100_40gb | 26.75 | 26.75 | 512             | 8              | 1         | 2667             | 5462972          | 85358                | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760  |
-| gpt125m | 2048       | 64      | a100_40gb | 20.61 | 20.61 | 256             | 4              | 1         | 2054             | 4208218          | 65753                | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760  |
+| gpt125m | 2048       | 64      | a100_40gb | 20.61 | 20.61 | 256             | 4              | 1         | 2054             | 4208218          | 65753                | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760  | -->

--- a/examples/llm/throughput/README.md
+++ b/examples/llm/throughput/README.md
@@ -2,18 +2,22 @@
 
 Benchmark measurements for MosaicGPT models trained on [MosaicML platform](https://www.mosaicml.com/platform), including throughput, MFU, and HFU. Each model is based on optimized configurations of various sizes in the [yamls](../yamls) folder, ranging from a 125m to 70B parameter models.
 
-To reproduce these results, first:
+To reproduce table results, first run:
 ```
-python submit_benchmarks.py --cluster [your_mosaicml_cluster] ARGS --RUN
+./sweep.sh
 ```
-
-will use our Python API to submit a sweep of the specified configurations.
 
 Then, after the runs are completed:
 ```
 python collect_results.py --save-path results
 ```
 will use our Python API to collect and calculate the benchmark results, and then save as both a CSV file `results.csv`, and a markdown table `results.md`.
+
+
+```
+python submit_benchmarks.py --cluster [your_mosaicml_cluster] ARGS --RUN
+```
+can be used to sweep a larger set of configurations. For example usage of `submit_benchmarks.py` see `sweep.sh` which lists all benchmarks in the tables.
 
 > **Note**
 > The `collect_results.py` will by default find all runs with `tput` in the run name. To customize this project tag, use `--project` in both the submissing and collection scripts.
@@ -61,7 +65,7 @@ python submit_benchmarks.py -m 13b.yaml 30b.yaml -t fp16 -b 21 21 -s 11 14 --RUN
 ```
 This will run 8 configs for 12 steps to get throughput numbers. `python collect_results.py` can then be used to parse all output training logs and create the tables below.
 
-Sometimes we report Global Batchsizes that are not evenly divisible by the micro batch size. Our microbatching engine allows for non-divisible sizes, while being mathematically faithful to the global batch size. For example, a total batch size of 48, and a micro batch of 11, means we will accumulate gradients across microbatches of 11, 11, 11, 11, 4.
+Our microbatching engine enables microbatch sizes that do not divde Global Batchsize while being mathematically faithful to the global batch size. For example, a total batch size of 48, and a micro batch of 11, means we will accumulate gradients across microbatches of 11, 11, 11, 11, 4.
 
 #### TODO: Updated using torch 2.0
 
@@ -156,248 +160,85 @@ Sometimes we report Global Batchsizes that are not evenly divisible by the micro
 |  125m | 1024 | 8 | a100_80gb | 43.25 | 43.25 | 64 | 2 | 1024 | 1225 | 1254561 | 156820 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 124525056 |
 |  125m | 512 | 8 | a100_80gb | 42.54 | 42.54 | 128 | 2 | 2048 | 2587 | 1325030 | 165628 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 124131840 |
 
-
-
-
-
-
-
-
-
-
-<!-- 
-
-
-
-## Warning: Some of the numbers below, particularly for 30B and 70B models, are out of date. The current repo achieves higher throughput / MFU. This warning will be removed once the tables are updated.
-
-# MosaicGPT Training Benchmarks
-
-Benchmark measurements for MosaicGPT models trained on [MosaicML platform](https://www.mosaicml.com/platform), including throughput, MFU, and HFU. Each model is based on optimized configurations of various sizes in the [yamls](../yamls) folder, ranging from a 125m to 70B parameter models.
-
-To reproduce these results, first:
-```
-python submit_benchmarks.py -m 125m.yaml --cluster [your_mosaicml_cluster] --RUN
-```
-
-will use our Python API to submit a sweep of configurations for the 125M parameter model. To run all the configurations, omit the `-m` flag.
-
-Then, after the runs are completed:
-```
-python collect_results.py --save-path results
-```
-will use our Python API to collect and calculate the benchmark results, and then save as both a CSV file `results.csv`, and a markdown table `results.md`.
-
-> **Note**
-> The `collect_results.py` will by default find all runs with `tput` in the run name. To customize this project tag, use `--project` in both the submissing and collection scripts.
-
-
-## MFU and HFU
-
-Model FLOPs Utilization (MFU) and Hardware FLOPS Utilization (HFU) are estimates, based on the throughput and the known FLOPs of the computation, of what percentage of the hardware's FLOPs are being used during training.
-
-MFU calculates the utilizaiton from the floating point operations required for a single forward/backwards pass of the model, and do not account for the additional compute required for other implementation details such as activation checkpointing. Thus, MFU is independant of implementation and hardware.
-
-HFU attempt to capture the actual floating point operations incurred during the forward/backwards pass on the hardware, and is a more accurate measurement of hardware utilization, but less general and difficult to compare across various hardware and implementation details.
-
-For more information, see [Korthikanti et al, 2022](https://arxiv.org/abs/2205.05198). All FLOP calculations exclude the operations required for normalization, activation, and residuals.
-
-### MFU
-
-Per token, each parameter is used for a MAC (2 FLOPS) per network operation. Neural Network training has 3 network operations: forward pass, backward pass, and computation of parameter gradient.
-
-The attention mechanism forward pass FLOPS are: `attn_flops_per_seq = n_layers * 2 * 2 * (d_model * (seq_len**2))`
-```
-flops_per_token = 2 * n_params
-flops_per_seq = flops_per_token * seq_len
-mfu* = 3 * flops_per_seq * throughput / (gpu_num * GPU_AVAILABLE_FLOPS)
-
-attn_flops_per_seq = n_layers * 2 * 2 * (d_model * (seq_len**2))
-mfu = (3 * flops_per_seq + 3 * attn_flops_per_seq) * throughput / (gpu_num * GPU_AVAILABLE_FLOPS)
-```
-
-### HFU
-
-The HFU numbers shown below account for the fact that the networks use checkpointing and recomputes activations. This effectively requires an extra forward pass through the network.
-```
-hfu* = 4 * flops_per_seq * throughput / (gpu_num * GPU_AVAILABLE_FLOPS)
-hfu = (4 * flops_per_seq + 4 * attn_flops_per_seq) * throughput / (gpu_num * GPU_AVAILABLE_FLOPS)
-```
-
-Note that these are approximations. Actual HFU would be higher since it includes the floating point operations for normalization, activation, and residual lyaers, as well as **all** recomputation. For example, our models use Flash Attention, which requires including an extra recompute factor for its recomputation in the forward pass. Therefore, the attention multipler would be 5 instead of 4.
-
-## Results
-
-Below we include several configurations across different hardware platforms, sequence lengths and batch sizes. It is easy to benchmark configurations for your own use case. For example, using Mosaic Cloud, to test MosaicGPT {13B, 30B} using fp16 with a batch size of 2M tokens and seq len {2k, 4k, 8k, 16k} run:
-```
-python submit_benchmarks.py -m 13b.yaml 30b.yaml -t fp16 -b 21 21 -s 11 14 --RUN
-```
-This will run 8 configs for 12 steps to get throughput numbers. `python collect_results.py` can then be used to parse all output training logs and create the tables below.
-
-Sometimes we report Global Batchsizes that are not evenly divisible by the micro batch size. Our microbatching engine allows for non-divisible sizes, while being mathematically faithful to the global batch size. For example, a total batch size of 48, and a micro batch of 11, means we will accumulate gradients across microbatches of 11, 11, 11, 11, 4.
-
-## A100 80GB
-
-Note: The 30B -> 70B measurements below are outdated, and will be updated shortly.
-
-| Model   | SeqLen (T) | GPUType       | MFU    | HFU    | Throughput (T/s) | GPUThroughput (T/s/GPU) | Throughput (S/s) | ParamCount  | GlobalBatchSize (T) | GlobalBatchSize (S) | MicroBatchSize (S) | GradAccum | ShardStrategy | ActCkpt | ActCPUoffload | Precision | MP Mode | NumGPUs | GPUType   |
-| ------- | ---------- | ------------- | ------ | ------ | ------ | ------ | ---------------- | ----------------------- | ---------------- | ----------- | ------------------- | ------------------- | ------------------ | --------- | ------------- | ------- | ------------- | --------- | ------- |
-|  gpt70b |       2048 | 128xA100_80GB | 0.4265 | 0.5687 |         42028.81 |                328.3501 |          20.5219 | 64861528064 |             2097152 |                1024 |                  8 |         1 |    FULL_SHARD |    True |         False |  amp_bf16 | DEFAULT |     128 | a100_80gb |
-|  gpt30b |       8192 |  64xA100_80GB | 0.4502 | 0.6003 |         42023.16 |                656.6118 |           5.1298 | 30018458624 |             1048576 |                 128 |                  2 |         1 |    FULL_SHARD |    True |         False |  amp_bf16 | DEFAULT |      64 | a100_80gb |
-|  gpt30b |       8192 |  32xA100_80GB | 0.4435 | 0.5914 |         20698.23 |                646.8198 |           2.5266 | 30018458624 |              524288 |                  64 |                  2 |         1 |    FULL_SHARD |    True |         False |  amp_bf16 | DEFAULT |      32 | a100_80gb |
-|  gpt30b |       4096 | 128xA100_80GB | 0.4649 | 0.6198 |         94312.24 |                736.8144 |          23.0254 | 29989098496 |             2097152 |                 512 |                  4 |         1 |    FULL_SHARD |    True |         False |  amp_bf16 | DEFAULT |     128 | a100_80gb |
-|  gpt30b |       4096 |  32xA100_80GB | 0.4644 | 0.6192 |         23553.76 |                736.0550 |           5.7504 | 29989098496 |              524288 |                 128 |                  4 |         1 |    FULL_SHARD |    True |         False |  amp_bf16 | DEFAULT |      32 | a100_80gb |
-|  gpt30b |       2048 | 256xA100_80GB | 0.4674 | 0.6232 |        198267.62 |                774.4829 |          96.8104 | 29974418432 |             4194304 |                2048 |                  8 |         1 |    FULL_SHARD |    True |         False |  amp_bf16 | DEFAULT |     256 | a100_80gb |
-|  gpt30b |       2048 | 128xA100_80GB | 0.4762 | 0.6349 |        100995.65 |                789.0285 |          49.3143 | 29974418432 |             2097152 |                1024 |                  8 |         1 |    FULL_SHARD |    True |         False |  amp_bf16 | DEFAULT |     128 | a100_80gb |
-|  gpt30b |       2048 |  64xA100_80GB | 0.4777 | 0.6369 |         50651.59 |                791.4310 |          24.7322 | 29974418432 |             1048576 |                 512 |                  8 |         1 |    FULL_SHARD |    True |         False |  amp_bf16 | DEFAULT |      64 | a100_80gb |
-|  gpt30b |       2048 |  32xA100_80GB | 0.4796 | 0.6394 |         25427.85 |                794.6202 |          12.4159 | 29974418432 |              524288 |                 256 |                  8 |         1 |    FULL_SHARD |    True |         False |  amp_bf16 | DEFAULT |      32 | a100_80gb |
-|  gpt30b |       2048 |  16xA100_80GB | 0.4777 | 0.6369 |         12663.75 |                791.4842 |           6.1835 | 29974418432 |              262144 |                 128 |                  8 |         1 |    FULL_SHARD |    True |         False |  amp_bf16 | DEFAULT |      16 | a100_80gb |
-
-The <30B measurements below reflect the latest version of our codebase:
-
-| Model   | SeqLen (T) | \# GPUs | GPU       | MFU   | HFU   | Global BatchSize | Micro BatchSize | GradAccum | Throughput (S/s) | Throughput (T/s) | Throughput (T/s/GPU) | GlobalBatchSize (T) | Precision | MP Mode | Sharding Strategy | Activation Checkpointing | Activation CPUOffload | NumParams   |
-| ------- | ---------- | ------- | --------- | ----- | ----- | --------------- | -------------- | --------- | ---------------- | ---------------- | -------------------- | ------------------- | --------- | ------- | ----------------- | ------------------------ | --------------------- | ----------- |
-| gpt13b  | 2048       | 8       | a100_80gb | 47.82 | 63.75 | 2048            | 12             | 22        | 7                | 14527            | 1815                 | 4194304             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 12853463040 |
-| gpt13b  | 2048       | 8       | a100_80gb | 47.82 | 63.76 | 1024            | 12             | 11        | 7                | 14527            | 1815                 | 2097152             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 12853463040 |
-| gpt13b  | 2048       | 8       | a100_80gb | 47.61 | 63.48 | 512             | 12             | 6         | 7                | 14463            | 1807                 | 1048576             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 12853463040 |
-| gpt13b  | 2048       | 8       | a100_80gb | 47.59 | 63.45 | 256             | 12             | 3         | 7                | 14457            | 1807                 | 524288              | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 12853463040 |
-| gpt13b  | 2048       | 16      | a100_80gb | 48.26 | 64.34 | 2048            | 16             | 8         | 14               | 29322            | 1832                 | 4194304             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 12853463040 |
-| gpt13b  | 2048       | 16      | a100_80gb | 48.25 | 64.34 | 1024            | 16             | 4         | 14               | 29319            | 1832                 | 2097152             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 12853463040 |
-| gpt13b  | 2048       | 16      | a100_80gb | 48.27 | 64.36 | 512             | 16             | 2         | 14               | 29329            | 1833                 | 1048576             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 12853463040 |
-| gpt13b  | 2048       | 16      | a100_80gb | 48.22 | 64.29 | 256             | 16             | 1         | 14               | 29298            | 1831                 | 524288              | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 12853463040 |
-| gpt7b   | 2048       | 8       | a100_80gb | 46.24 | 61.66 | 2048            | 20             | 13        | 13               | 26736            | 3342                 | 4194304             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 6658465792  |
-| gpt7b   | 2048       | 8       | a100_80gb | 46.88 | 62.51 | 1024            | 20             | 7         | 13               | 27104            | 3388                 | 2097152             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 6658465792  |
-| gpt7b   | 2048       | 8       | a100_80gb | 46.29 | 61.72 | 512             | 20             | 4         | 13               | 26761            | 3345                 | 1048576             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 6658465792  |
-| gpt7b   | 2048       | 8       | a100_80gb | 46.53 | 62.04 | 256             | 20             | 2         | 13               | 26900            | 3362                 | 524288              | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 6658465792  |
-| gpt7b   | 2048       | 16      | a100_80gb | 46.44 | 61.92 | 2048            | 20             | 7         | 26               | 53700            | 3356                 | 4194304             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 6658465792  |
-| gpt7b   | 2048       | 16      | a100_80gb | 46.26 | 61.68 | 1024            | 20             | 4         | 26               | 53490            | 3343                 | 2097152             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 6658465792  |
-| gpt7b   | 2048       | 16      | a100_80gb | 46.22 | 61.62 | 512             | 20             | 2         | 26               | 53441            | 3340                 | 1048576             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 6658465792  |
-| gpt7b   | 2048       | 16      | a100_80gb | 46.18 | 61.57 | 256             | 16             | 1         | 26               | 53398            | 3337                 | 524288              | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 6658465792  |
-| gpt3b   | 2048       | 8       | a100_80gb | 51.01 | 51.01 | 2048            | 6              | 43        | 34               | 71045            | 8880                 | 4194304             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 2651591680  |
-| gpt3b   | 2048       | 8       | a100_80gb | 50.73 | 50.73 | 1024            | 6              | 22        | 34               | 70651            | 8831                 | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 2651591680  |
-| gpt3b   | 2048       | 8       | a100_80gb | 50.94 | 50.94 | 512             | 6              | 11        | 34               | 70945            | 8868                 | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 2651591680  |
-| gpt3b   | 2048       | 8       | a100_80gb | 50.17 | 50.17 | 256             | 6              | 6         | 34               | 69870            | 8733                 | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 2651591680  |
-| gpt3b   | 2048       | 16      | a100_80gb | 49.89 | 49.89 | 2048            | 6              | 22        | 67               | 138946           | 8684                 | 4194304             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 2651591680  |
-| gpt3b   | 2048       | 16      | a100_80gb | 50    | 50    | 1024            | 6              | 11        | 68               | 139264           | 8704                 | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 2651591680  |
-| gpt3b   | 2048       | 16      | a100_80gb | 49.66 | 49.66 | 512             | 6              | 6         | 67               | 138327           | 8645                 | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 2651591680  |
-| gpt3b   | 2048       | 16      | a100_80gb | 49.63 | 49.63 | 256             | 6              | 3         | 67               | 138222           | 8638                 | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 2651591680  |
-| gpt1b   | 2048       | 8       | a100_80gb | 50.1  | 50.1  | 2048            | 10             | 26        | 67               | 137376           | 17172                | 4194304             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 1315753984  |
-| gpt1b   | 2048       | 8       | a100_80gb | 49.43 | 49.43 | 1024            | 10             | 13        | 66               | 135530           | 16941                | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 1315753984  |
-| gpt1b   | 2048       | 8       | a100_80gb | 49.81 | 49.81 | 512             | 10             | 7         | 66               | 136572           | 17071                | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 1315753984  |
-| gpt1b   | 2048       | 8       | a100_80gb | 49.54 | 49.54 | 256             | 10             | 4         | 66               | 135854           | 16981                | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 1315753984  |
-| gpt1b   | 2048       | 16      | a100_80gb | 49.47 | 49.47 | 2048            | 10             | 13        | 132              | 271315           | 16957                | 4194304             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 1315753984  |
-| gpt1b   | 2048       | 16      | a100_80gb | 49.23 | 49.23 | 1024            | 10             | 7         | 131              | 269990           | 16874                | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 1315753984  |
-| gpt1b   | 2048       | 16      | a100_80gb | 48.75 | 48.75 | 512             | 10             | 4         | 130              | 267354           | 16709                | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 1315753984  |
-| gpt1b   | 2048       | 16      | a100_80gb | 48.74 | 48.74 | 256             | 10             | 2         | 130              | 267317           | 16707                | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 1315753984  |
-| gpt760m | 2048       | 8       | a100_80gb | 45.66 | 45.66 | 2048            | 12             | 22        | 101              | 208439           | 26054                | 4194304             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 760323072   |
-| gpt760m | 2048       | 8       | a100_80gb | 45.88 | 45.88 | 1024            | 12             | 11        | 102              | 209427           | 26178                | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 760323072   |
-| gpt760m | 2048       | 8       | a100_80gb | 45.87 | 45.87 | 512             | 12             | 6         | 102              | 209369           | 26171                | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 760323072   |
-| gpt760m | 2048       | 8       | a100_80gb | 45.81 | 45.81 | 256             | 12             | 3         | 102              | 209104           | 26138                | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 760323072   |
-| gpt760m | 2048       | 16      | a100_80gb | 45.37 | 45.37 | 2048            | 12             | 11        | 202              | 414201           | 25887                | 4194304             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 760323072   |
-| gpt760m | 2048       | 16      | a100_80gb | 44.95 | 44.95 | 1024            | 12             | 6         | 200              | 410357           | 25647                | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 760323072   |
-| gpt760m | 2048       | 16      | a100_80gb | 45.08 | 45.08 | 512             | 12             | 3         | 200              | 411602           | 25725                | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 760323072   |
-| gpt760m | 2048       | 16      | a100_80gb | 43.82 | 43.82 | 256             | 12             | 2         | 195              | 400053           | 25003                | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 760323072   |
-| gpt350m | 2048       | 8       | a100_80gb | 41.02 | 41.02 | 2048            | 16             | 16        | 182              | 373810           | 46726                | 4194304             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 355887104   |
-| gpt350m | 2048       | 8       | a100_80gb | 41.4  | 41.4  | 1024            | 16             | 8         | 184              | 377236           | 47154                | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 355887104   |
-| gpt350m | 2048       | 8       | a100_80gb | 41.22 | 41.22 | 512             | 16             | 4         | 183              | 375552           | 46944                | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 355887104   |
-| gpt350m | 2048       | 8       | a100_80gb | 41.04 | 41.04 | 256             | 16             | 2         | 182              | 373972           | 46746                | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 355887104   |
-| gpt350m | 2048       | 16      | a100_80gb | 40.86 | 40.86 | 2048            | 16             | 8         | 363              | 744662           | 46541                | 4194304             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 355887104   |
-| gpt350m | 2048       | 16      | a100_80gb | 40.92 | 40.92 | 1024            | 16             | 4         | 364              | 745717           | 46607                | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 355887104   |
-| gpt350m | 2048       | 16      | a100_80gb | 40.88 | 40.88 | 512             | 16             | 2         | 363              | 744910           | 46556                | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 355887104   |
-| gpt350m | 2048       | 16      | a100_80gb | 40.77 | 40.77 | 256             | 16             | 1         | 362              | 742945           | 46434                | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 355887104   |
-| gpt125m | 2048       | 8       | a100_80gb | 34.58 | 34.58 | 2048            | 32             | 8         | 430              | 882486           | 110310               | 4194304             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760   |
-| gpt125m | 2048       | 8       | a100_80gb | 34.64 | 34.64 | 1024            | 32             | 4         | 431              | 884215           | 110526               | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760   |
-| gpt125m | 2048       | 8       | a100_80gb | 34.82 | 34.82 | 512             | 32             | 2         | 433              | 888646           | 111080               | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760   |
-| gpt125m | 2048       | 8       | a100_80gb | 34.45 | 34.45 | 256             | 32             | 1         | 429              | 879324           | 109915               | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760   |
-| gpt125m | 2048       | 16      | a100_80gb | 34.5  | 34.5  | 2048            | 32             | 4         | 860              | 1761358          | 110084               | 4194304             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760   |
-| gpt125m | 2048       | 16      | a100_80gb | 34.51 | 34.51 | 1024            | 32             | 2         | 860              | 1761842          | 110115               | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760   |
-| gpt125m | 2048       | 16      | a100_80gb | 34.3  | 34.3  | 512             | 32             | 1         | 854              | 1750997          | 109437               | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760   |
-| gpt125m | 2048       | 16      | a100_80gb | 32.54 | 32.54 | 256             | 16             | 1         | 811              | 1661141          | 103821               | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760   |
-
 ## A100 40GB
 
-| Model   | SeqLen (T) | \# GPUs | GPU       | MFU   | HFU   | Global BatchSize | Micro BatchSize | GradAccum | Throughput (S/s) | Throughput (T/s) | Throughput (T/s/GPU) | Global BatchSize (T) | Precision | MP Mode | Sharding Strategy | Activation Checkpointing | Activation CPUOffload | NumParams  |
-| ------- | ---------- | ------- | --------- | ----- | ----- | --------------- | -------------- | --------- | ---------------- | ---------------- | -------------------- | ------------------- | --------- | ------- | ----------------- | ------------------------ | --------------------- | ---------- |
-| gpt7b   | 2048       | 8       | a100_40gb | 42.21 | 56.28 | 2048            | 6              | 43        | 11               | 24404            | 3050                 | 4194304             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 6658465792 |
-| gpt7b   | 2048       | 8       | a100_40gb | 41.96 | 55.94 | 1024            | 6              | 22        | 11               | 24256            | 3032                 | 2097152             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 6658465792 |
-| gpt7b   | 2048       | 8       | a100_40gb | 41.96 | 55.95 | 512             | 6              | 11        | 11               | 24261            | 3032                 | 1048576             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 6658465792 |
-| gpt7b   | 2048       | 8       | a100_40gb | 41.81 | 55.75 | 256             | 6              | 6         | 11               | 24175            | 3021                 | 524288              | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 6658465792 |
-| gpt7b   | 2048       | 16      | a100_40gb | 43.22 | 57.63 | 2048            | 8              | 16        | 24               | 49977            | 3123                 | 4194304             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 6658465792 |
-| gpt7b   | 2048       | 16      | a100_40gb | 43.04 | 57.38 | 1024            | 8              | 8         | 24               | 49763            | 3110                 | 2097152             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 6658465792 |
-| gpt7b   | 2048       | 16      | a100_40gb | 42.94 | 57.26 | 512             | 8              | 4         | 24               | 49654            | 3103                 | 1048576             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 6658465792 |
-| gpt7b   | 2048       | 16      | a100_40gb | 42.76 | 57.02 | 256             | 8              | 2         | 24               | 49447            | 3090                 | 524288              | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 6658465792 |
-| gpt7b   | 2048       | 32      | a100_40gb | 42.87 | 57.16 | 2048            | 8              | 8         | 48               | 99133            | 3097                 | 4194304             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 6658465792 |
-| gpt7b   | 2048       | 32      | a100_40gb | 42.97 | 57.3  | 1024            | 8              | 4         | 48               | 99383            | 3105                 | 2097152             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 6658465792 |
-| gpt7b   | 2048       | 32      | a100_40gb | 42.95 | 57.27 | 512             | 8              | 2         | 48               | 99328            | 3104                 | 1048576             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 6658465792 |
-| gpt7b   | 2048       | 32      | a100_40gb | 42.89 | 57.19 | 256             | 8              | 1         | 48               | 99195            | 3099                 | 524288              | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 6658465792 |
-| gpt7b   | 2048       | 64      | a100_40gb | 42.37 | 56.5  | 1024            | 8              | 2         | 95               | 195987           | 3062                 | 2097152             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 6658465792 |
-| gpt3b   | 2048       | 8       | a100_40gb | 39.73 | 52.98 | 2048            | 14             | 19        | 27               | 55335            | 6916                 | 4194304             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 2651591680 |
-| gpt3b   | 2048       | 8       | a100_40gb | 39.82 | 53.09 | 1024            | 14             | 10        | 27               | 55454            | 6931                 | 2097152             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 2651591680 |
-| gpt3b   | 2048       | 8       | a100_40gb | 39.68 | 52.91 | 512             | 14             | 5         | 26               | 55259            | 6907                 | 1048576             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 2651591680 |
-| gpt3b   | 2048       | 8       | a100_40gb | 39.24 | 52.31 | 256             | 14             | 3         | 26               | 54641            | 6830                 | 524288              | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 2651591680 |
-| gpt3b   | 2048       | 16      | a100_40gb | 39.46 | 52.61 | 2048            | 14             | 10        | 53               | 109905           | 6869                 | 4194304             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 2651591680 |
-| gpt3b   | 2048       | 16      | a100_40gb | 39.27 | 52.36 | 1024            | 14             | 5         | 53               | 109367           | 6835                 | 2097152             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 2651591680 |
-| gpt3b   | 2048       | 16      | a100_40gb | 38.77 | 51.69 | 512             | 14             | 3         | 52               | 107971           | 6748                 | 1048576             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 2651591680 |
-| gpt3b   | 2048       | 16      | a100_40gb | 37.87 | 50.49 | 256             | 14             | 2         | 51               | 105470           | 6591                 | 524288              | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 2651591680 |
-| gpt3b   | 2048       | 32      | a100_40gb | 37.94 | 50.58 | 2048            | 8              | 8         | 103              | 211333           | 6604                 | 4194304             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 2651591680 |
-| gpt3b   | 2048       | 32      | a100_40gb | 38.51 | 51.35 | 1024            | 14             | 3         | 104              | 214529           | 6704                 | 2097152             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 2651591680 |
-| gpt3b   | 2048       | 32      | a100_40gb | 37.92 | 50.56 | 512             | 14             | 2         | 103              | 211250           | 6601                 | 1048576             | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 2651591680 |
-| gpt3b   | 2048       | 32      | a100_40gb | 37.68 | 50.25 | 256             | 8              | 1         | 102              | 209919           | 6559                 | 524288              | bf16      | DEFAULT | FULL_SHARD        | TRUE                     | FALSE                 | 2651591680 |
-| gpt1b   | 2048       | 8       | a100_40gb | 44.23 | 44.23 | 2048            | 4              | 64        | 59               | 121285           | 15160                | 4194304             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 1315753984 |
-| gpt1b   | 2048       | 8       | a100_40gb | 44.32 | 44.32 | 1024            | 4              | 32        | 59               | 121517           | 15189                | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 1315753984 |
-| gpt1b   | 2048       | 8       | a100_40gb | 44.22 | 44.22 | 512             | 4              | 16        | 59               | 121265           | 15158                | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 1315753984 |
-| gpt1b   | 2048       | 8       | a100_40gb | 43.73 | 43.73 | 256             | 4              | 8         | 58               | 119913           | 14989                | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 1315753984 |
-| gpt1b   | 2048       | 16      | a100_40gb | 42.52 | 42.52 | 2048            | 4              | 32        | 113              | 233203           | 14575                | 4194304             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 1315753984 |
-| gpt1b   | 2048       | 16      | a100_40gb | 42.54 | 42.54 | 1024            | 4              | 16        | 113              | 233280           | 14580                | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 1315753984 |
-| gpt1b   | 2048       | 16      | a100_40gb | 42.38 | 42.38 | 512             | 4              | 8         | 113              | 232440           | 14527                | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 1315753984 |
-| gpt1b   | 2048       | 16      | a100_40gb | 42.35 | 42.35 | 256             | 4              | 4         | 113              | 232270           | 14516                | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 1315753984 |
-| gpt1b   | 2048       | 32      | a100_40gb | 41.45 | 41.45 | 2048            | 4              | 16        | 222              | 454695           | 14209                | 4194304             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 1315753984 |
-| gpt1b   | 2048       | 32      | a100_40gb | 41.84 | 41.84 | 1024            | 4              | 8         | 224              | 458925           | 14341                | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 1315753984 |
-| gpt1b   | 2048       | 32      | a100_40gb | 41.86 | 41.86 | 512             | 4              | 4         | 224              | 459188           | 14349                | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 1315753984 |
-| gpt1b   | 2048       | 32      | a100_40gb | 41.75 | 41.75 | 256             | 4              | 2         | 223              | 457923           | 14310                | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 1315753984 |
-| gpt760m | 2048       | 8       | a100_40gb | 41.69 | 41.69 | 2048            | 6              | 43        | 92               | 190290           | 23786                | 4194304             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 760323072  |
-| gpt760m | 2048       | 8       | a100_40gb | 41.94 | 41.94 | 1024            | 6              | 22        | 93               | 191426           | 23928                | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 760323072  |
-| gpt760m | 2048       | 8       | a100_40gb | 41.64 | 41.64 | 512             | 6              | 11        | 92               | 190099           | 23762                | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 760323072  |
-| gpt760m | 2048       | 8       | a100_40gb | 41.14 | 41.14 | 256             | 6              | 6         | 91               | 187790           | 23473                | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 760323072  |
-| gpt760m | 2048       | 16      | a100_40gb | 40.42 | 40.42 | 2048            | 6              | 22        | 180              | 369035           | 23064                | 4194304             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 760323072  |
-| gpt760m | 2048       | 16      | a100_40gb | 40.32 | 40.32 | 1024            | 6              | 11        | 179              | 368100           | 23006                | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 760323072  |
-| gpt760m | 2048       | 16      | a100_40gb | 40.82 | 40.82 | 512             | 6              | 6         | 181              | 372704           | 23294                | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 760323072  |
-| gpt760m | 2048       | 16      | a100_40gb | 40.01 | 40.01 | 256             | 6              | 3         | 178              | 365250           | 22828                | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 760323072  |
-| gpt760m | 2048       | 32      | a100_40gb | 40.32 | 40.32 | 2048            | 6              | 11        | 359              | 736144           | 23004                | 4194304             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 760323072  |
-| gpt760m | 2048       | 32      | a100_40gb | 39.67 | 39.67 | 1024            | 6              | 6         | 353              | 724385           | 22637                | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 760323072  |
-| gpt760m | 2048       | 32      | a100_40gb | 39.59 | 39.59 | 512             | 6              | 3         | 352              | 722799           | 22587                | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 760323072  |
-| gpt760m | 2048       | 32      | a100_40gb | 37.52 | 37.52 | 256             | 6              | 2         | 334              | 685107           | 21409                | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 760323072  |
-| gpt760m | 2048       | 64      | a100_40gb | 38.89 | 38.89 | 1024            | 6              | 3         | 693              | 1420188          | 22190                | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 760323072  |
-| gpt760m | 2048       | 64      | a100_40gb | 36.45 | 36.45 | 512             | 6              | 2         | 649              | 1330954          | 20796                | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 760323072  |
-| gpt760m | 2048       | 64      | a100_40gb | 35.58 | 35.58 | 256             | 4              | 1         | 634              | 1299158          | 20299                | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 760323072  |
-| gpt350m | 2048       | 8       | a100_40gb | 37.77 | 37.77 | 2048            | 8              | 32        | 168              | 344113           | 43014                | 4194304             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 355887104  |
-| gpt350m | 2048       | 8       | a100_40gb | 37.52 | 37.52 | 1024            | 8              | 16        | 166              | 341842           | 42730                | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 355887104  |
-| gpt350m | 2048       | 8       | a100_40gb | 37.62 | 37.62 | 512             | 8              | 8         | 167              | 342831           | 42853                | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 355887104  |
-| gpt350m | 2048       | 8       | a100_40gb | 37.34 | 37.34 | 256             | 8              | 4         | 166              | 340210           | 42526                | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 355887104  |
-| gpt350m | 2048       | 16      | a100_40gb | 36.83 | 36.83 | 2048            | 8              | 16        | 327              | 671137           | 41946                | 4194304             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 355887104  |
-| gpt350m | 2048       | 16      | a100_40gb | 36.58 | 36.58 | 1024            | 8              | 8         | 325              | 666661           | 41666                | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 355887104  |
-| gpt350m | 2048       | 16      | a100_40gb | 36.64 | 36.64 | 512             | 8              | 4         | 326              | 667779           | 41736                | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 355887104  |
-| gpt350m | 2048       | 16      | a100_40gb | 36.62 | 36.62 | 256             | 8              | 2         | 325              | 667372           | 41710                | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 355887104  |
-| gpt350m | 2048       | 32      | a100_40gb | 36.13 | 36.13 | 2048            | 8              | 8         | 643              | 1316894          | 41152                | 4194304             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 355887104  |
-| gpt350m | 2048       | 32      | a100_40gb | 35.94 | 35.94 | 1024            | 8              | 4         | 639              | 1310082          | 40940                | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 355887104  |
-| gpt350m | 2048       | 32      | a100_40gb | 36.21 | 36.21 | 512             | 8              | 2         | 644              | 1319869          | 41245                | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 355887104  |
-| gpt350m | 2048       | 32      | a100_40gb | 35.68 | 35.68 | 256             | 8              | 1         | 635              | 1300518          | 40641                | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 355887104  |
-| gpt350m | 2048       | 64      | a100_40gb | 35.57 | 35.57 | 1024            | 8              | 2         | 1266             | 2593124          | 40517                | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 355887104  |
-| gpt350m | 2048       | 64      | a100_40gb | 35    | 35    | 512             | 8              | 1         | 1245             | 2551575          | 39868                | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 355887104  |
-| gpt350m | 2048       | 64      | a100_40gb | 29.27 | 29.27 | 256             | 4              | 1         | 1041             | 2133414          | 33334                | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 355887104  |
-| gpt125m | 2048       | 8       | a100_40gb | 31.84 | 31.84 | 2048            | 16             | 16        | 396              | 812783           | 101597               | 4194304             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760  |
-| gpt125m | 2048       | 8       | a100_40gb | 31.88 | 31.88 | 1024            | 16             | 8         | 397              | 813735           | 101716               | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760  |
-| gpt125m | 2048       | 8       | a100_40gb | 31.9  | 31.9  | 512             | 16             | 4         | 397              | 814313           | 101789               | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760  |
-| gpt125m | 2048       | 8       | a100_40gb | 31.68 | 31.68 | 256             | 16             | 2         | 394              | 808703           | 101087               | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760  |
-| gpt125m | 2048       | 16      | a100_40gb | 31.42 | 31.42 | 2048            | 16             | 8         | 783              | 1604064          | 100254               | 4194304             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760  |
-| gpt125m | 2048       | 16      | a100_40gb | 31.41 | 31.41 | 1024            | 16             | 4         | 782              | 1603181          | 100198               | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760  |
-| gpt125m | 2048       | 16      | a100_40gb | 31.38 | 31.38 | 512             | 16             | 2         | 782              | 1601984          | 100124               | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760  |
-| gpt125m | 2048       | 16      | a100_40gb | 30.83 | 30.83 | 256             | 16             | 1         | 768              | 1573714          | 98357                | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760  |
-| gpt125m | 2048       | 32      | a100_40gb | 31.14 | 31.14 | 2048            | 16             | 4         | 1552             | 3179308          | 99353                | 4194304             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760  |
-| gpt125m | 2048       | 32      | a100_40gb | 31.03 | 31.03 | 1024            | 16             | 2         | 1546             | 3167949          | 98998                | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760  |
-| gpt125m | 2048       | 32      | a100_40gb | 30.54 | 30.54 | 512             | 16             | 1         | 1522             | 3117554          | 97423                | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760  |
-| gpt125m | 2048       | 32      | a100_40gb | 27.77 | 27.77 | 256             | 8              | 1         | 1384             | 2835086          | 88596                | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760  |
-| gpt125m | 2048       | 64      | a100_40gb | 30.23 | 30.23 | 2048            | 16             | 2         | 3014             | 6172908          | 96452                | 4194304             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760  |
-| gpt125m | 2048       | 64      | a100_40gb | 29.67 | 29.67 | 1024            | 16             | 1         | 2958             | 6059175          | 94674                | 2097152             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760  |
-| gpt125m | 2048       | 64      | a100_40gb | 26.75 | 26.75 | 512             | 8              | 1         | 2667             | 5462972          | 85358                | 1048576             | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760  |
-| gpt125m | 2048       | 64      | a100_40gb | 20.61 | 20.61 | 256             | 4              | 1         | 2054             | 4208218          | 65753                | 524288              | bf16      | DEFAULT | FULL_SHARD        | FALSE                    | FALSE                 | 125237760  | -->
+|  Model | SeqLen (T) | # GPUs | GPU | MFU | HFU | MicroBatchSize | GradAccum | GlobalBatchSize | Throughput (S/s) | Throughput (T/s) | Throughput (T/s/GPU) | GlobalBatchSize (T) | Precision | MP Mode | Sharding Strategy | Activation Checkpointing | Activation CPUOffload | NumParams |
+|  --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+|  70b | 2048 | 128 | a100_40gb | 48.91 | 65.21 | 4 | 1 | 512 | 23 | 48194 | 376 | 1048576 | bf16 | PURE | FULL_SHARD | True | False | 64862437376 |
+|  70b | 2048 | 64 | a100_40gb | 35.87 | 47.82 | 2 | 1 | 128 | 8 | 17672 | 276 | 262144 | bf16 | PURE | FULL_SHARD | True | False | 64862437376 |
+|  30b | 2048 | 128 | a100_40gb | 52.25 | 69.66 | 6 | 1 | 768 | 54 | 110803 | 865 | 1572864 | bf16 | PURE | FULL_SHARD | True | False | 29975214080 |
+|  30b | 2048 | 32 | a100_40gb | 51.74 | 68.98 | 4 | 1 | 128 | 13 | 27431 | 857 | 262144 | bf16 | PURE | FULL_SHARD | True | False | 29975214080 |
+|  13b | 8192 | 8 | a100_40gb | 43.95 | 58.6 | 1 | 16 | 128 | 1 | 11258 | 1407 | 1048576 | bf16 | PURE | FULL_SHARD | True | False | 12885411840 |
+|  13b | 4096 | 8 | a100_40gb | 44.85 | 59.8 | 2 | 16 | 256 | 3 | 12830 | 1603 | 1048576 | bf16 | PURE | FULL_SHARD | True | False | 12864440320 |
+|  13b | 2048 | 128 | a100_40gb | 51.93 | 69.24 | 16 | 1 | 2048 | 123 | 252444 | 1972 | 4194304 | bf16 | PURE | FULL_SHARD | True | False | 12853954560 |
+|  13b | 2048 | 64 | a100_40gb | 52.04 | 69.39 | 16 | 1 | 1024 | 61 | 126479 | 1976 | 2097152 | bf16 | PURE | FULL_SHARD | True | False | 12853954560 |
+|  13b | 2048 | 32 | a100_40gb | 52.62 | 70.16 | 14 | 1 | 448 | 31 | 63946 | 1998 | 917504 | bf16 | PURE | FULL_SHARD | True | False | 12853954560 |
+|  13b | 2048 | 16 | a100_40gb | 52.5 | 70.0 | 10 | 1 | 160 | 15 | 31900 | 1993 | 327680 | bf16 | PURE | FULL_SHARD | True | False | 12853954560 |
+|  13b | 2048 | 8 | a100_40gb | 43.94 | 58.58 | 4 | 16 | 512 | 6 | 13347 | 1668 | 1048576 | bf16 | PURE | FULL_SHARD | True | False | 12853954560 |
+|  13b | 1024 | 8 | a100_40gb | 44.07 | 58.76 | 8 | 16 | 1024 | 13 | 13817 | 1727 | 1048576 | bf16 | PURE | FULL_SHARD | True | False | 12848711680 |
+|  13b | 512 | 8 | a100_40gb | 44.28 | 59.04 | 16 | 16 | 2048 | 27 | 14108 | 1763 | 1048576 | bf16 | PURE | FULL_SHARD | True | False | 12846090240 |
+|  7b | 16384 | 8 | a100_40gb | 47.65 | 63.53 | 1 | 4 | 32 | 1 | 17998 | 2249 | 524288 | bf16 | PURE | FULL_SHARD | True | False | 6717579264 |
+|  7b | 8192 | 8 | a100_40gb | 49.04 | 65.38 | 3 | 4 | 96 | 2 | 23098 | 2887 | 786432 | bf16 | PURE | FULL_SHARD | True | False | 6684024832 |
+|  7b | 4096 | 8 | a100_40gb | 50.11 | 66.82 | 6 | 4 | 192 | 6 | 26930 | 3366 | 786432 | bf16 | PURE | FULL_SHARD | True | False | 6667247616 |
+|  7b | 2048 | 128 | a100_40gb | 50.14 | 66.85 | 18 | 1 | 2304 | 226 | 463749 | 3623 | 4718592 | bf16 | PURE | FULL_SHARD | True | False | 6658859008 |
+|  7b | 2048 | 64 | a100_40gb | 50.73 | 67.64 | 18 | 1 | 1152 | 114 | 234614 | 3665 | 2359296 | bf16 | PURE | FULL_SHARD | True | False | 6658859008 |
+|  7b | 2048 | 32 | a100_40gb | 51.55 | 68.73 | 18 | 1 | 576 | 58 | 119202 | 3725 | 1179648 | bf16 | PURE | FULL_SHARD | True | False | 6658859008 |
+|  7b | 2048 | 16 | a100_40gb | 50.44 | 67.26 | 16 | 1 | 256 | 28 | 58322 | 3645 | 524288 | bf16 | PURE | FULL_SHARD | True | False | 6658859008 |
+|  7b | 2048 | 8 | a100_40gb | 50.92 | 67.89 | 12 | 4 | 384 | 14 | 29436 | 3679 | 786432 | bf16 | PURE | FULL_SHARD | True | False | 6658859008 |
+|  7b | 1024 | 8 | a100_40gb | 51.31 | 68.42 | 24 | 4 | 768 | 30 | 30833 | 3854 | 786432 | bf16 | PURE | FULL_SHARD | True | False | 6654664704 |
+|  7b | 512 | 8 | a100_40gb | 50.85 | 67.8 | 48 | 4 | 1536 | 60 | 31167 | 3895 | 786432 | bf16 | PURE | FULL_SHARD | True | False | 6652567552 |
+|  3b | 32768 | 8 | a100_40gb | 46.03 | 61.37 | 1 | 4 | 32 | 0 | 23640 | 2955 | 1048576 | bf16 | PURE | FULL_SHARD | True | False | 2730480640 |
+|  3b | 16384 | 8 | a100_40gb | 46.14 | 61.52 | 2 | 8 | 128 | 2 | 35726 | 4465 | 2097152 | bf16 | PURE | FULL_SHARD | True | False | 2688537600 |
+|  3b | 8192 | 8 | a100_40gb | 55.13 | 55.13 | 1 | 8 | 64 | 6 | 57193 | 7149 | 524288 | bf16 | PURE | FULL_SHARD | False | False | 2667566080 |
+|  3b | 4096 | 8 | a100_40gb | 56.18 | 56.18 | 2 | 8 | 128 | 17 | 70223 | 8777 | 524288 | bf16 | PURE | FULL_SHARD | False | False | 2657080320 |
+|  3b | 2048 | 128 | a100_40gb | 54.8 | 54.8 | 6 | 1 | 768 | 596 | 1220885 | 9538 | 1572864 | bf16 | PURE | FULL_SHARD | False | False | 2651837440 |
+|  3b | 2048 | 64 | a100_40gb | 55.94 | 55.94 | 6 | 1 | 384 | 304 | 623167 | 9736 | 786432 | bf16 | PURE | FULL_SHARD | False | False | 2651837440 |
+|  3b | 2048 | 32 | a100_40gb | 56.96 | 56.96 | 6 | 1 | 192 | 154 | 317261 | 9914 | 393216 | bf16 | PURE | FULL_SHARD | False | False | 2651837440 |
+|  3b | 2048 | 16 | a100_40gb | 56.02 | 56.02 | 5 | 1 | 80 | 76 | 156013 | 9750 | 163840 | bf16 | PURE | FULL_SHARD | False | False | 2651837440 |
+|  3b | 2048 | 8 | a100_40gb | 57.82 | 57.82 | 5 | 8 | 320 | 39 | 80520 | 10065 | 655360 | bf16 | PURE | FULL_SHARD | False | False | 2651837440 |
+|  3b | 1024 | 8 | a100_40gb | 58.14 | 58.14 | 10 | 8 | 640 | 83 | 85854 | 10731 | 655360 | bf16 | PURE | FULL_SHARD | False | False | 2649216000 |
+|  3b | 512 | 8 | a100_40gb | 59.49 | 59.49 | 20 | 8 | 1280 | 176 | 90596 | 11324 | 655360 | bf16 | PURE | FULL_SHARD | False | False | 2647905280 |
+|  1b | 32768 | 8 | a100_40gb | 45.07 | 60.1 | 1 | 4 | 32 | 1 | 40762 | 5095 | 1048576 | bf16 | PURE | FULL_SHARD | True | False | 1378865152 |
+|  1b | 16384 | 8 | a100_40gb | 55.23 | 55.23 | 1 | 8 | 64 | 4 | 77723 | 9715 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 1345310720 |
+|  1b | 8192 | 8 | a100_40gb | 55.29 | 55.29 | 2 | 8 | 128 | 13 | 107799 | 13474 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 1328533504 |
+|  1b | 4096 | 8 | a100_40gb | 55.85 | 55.85 | 4 | 8 | 256 | 32 | 134851 | 16856 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 1320144896 |
+|  1b | 2048 | 128 | a100_40gb | 54.41 | 54.41 | 10 | 1 | 1280 | 1165 | 2386897 | 18647 | 2621440 | bf16 | PURE | FULL_SHARD | False | False | 1315950592 |
+|  1b | 2048 | 64 | a100_40gb | 55.44 | 55.44 | 10 | 1 | 640 | 593 | 1216104 | 19001 | 1310720 | bf16 | PURE | FULL_SHARD | False | False | 1315950592 |
+|  1b | 2048 | 32 | a100_40gb | 45.39 | 45.39 | 10 | 1 | 320 | 243 | 497782 | 15555 | 655360 | bf16 | PURE | FULL_SHARD | False | False | 1315950592 |
+|  1b | 2048 | 16 | a100_40gb | 55.69 | 55.69 | 8 | 1 | 128 | 149 | 305372 | 19085 | 262144 | bf16 | PURE | FULL_SHARD | False | False | 1315950592 |
+|  1b | 2048 | 8 | a100_40gb | 56.23 | 56.23 | 8 | 8 | 512 | 75 | 154171 | 19271 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 1315950592 |
+|  1b | 1024 | 8 | a100_40gb | 57.02 | 57.02 | 16 | 8 | 1024 | 163 | 167677 | 20959 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 1313853440 |
+|  1b | 512 | 8 | a100_40gb | 57.1 | 57.1 | 32 | 8 | 2048 | 340 | 174256 | 21782 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 1312804864 |
+|  760m | 32768 | 8 | a100_40gb | 44.53 | 59.37 | 1 | 4 | 32 | 1 | 57464 | 7183 | 1048576 | bf16 | PURE | FULL_SHARD | True | False | 807656448 |
+|  760m | 16384 | 8 | a100_40gb | 53.26 | 53.26 | 1 | 4 | 32 | 6 | 111316 | 13914 | 524288 | bf16 | PURE | FULL_SHARD | False | False | 782490624 |
+|  760m | 8192 | 8 | a100_40gb | 53.12 | 53.12 | 3 | 4 | 96 | 19 | 160853 | 20106 | 786432 | bf16 | PURE | FULL_SHARD | False | False | 769907712 |
+|  760m | 4096 | 8 | a100_40gb | 53.0 | 53.0 | 6 | 4 | 192 | 50 | 206909 | 25863 | 786432 | bf16 | PURE | FULL_SHARD | False | False | 763616256 |
+|  760m | 2048 | 128 | a100_40gb | 50.73 | 50.73 | 12 | 1 | 1536 | 1808 | 3704382 | 28940 | 3145728 | bf16 | PURE | FULL_SHARD | False | False | 760470528 |
+|  760m | 2048 | 64 | a100_40gb | 51.44 | 51.44 | 12 | 1 | 768 | 917 | 1878030 | 29344 | 1572864 | bf16 | PURE | FULL_SHARD | False | False | 760470528 |
+|  760m | 2048 | 32 | a100_40gb | 51.97 | 51.97 | 12 | 1 | 384 | 463 | 948745 | 29648 | 786432 | bf16 | PURE | FULL_SHARD | False | False | 760470528 |
+|  760m | 2048 | 16 | a100_40gb | 51.9 | 51.9 | 12 | 1 | 192 | 231 | 473723 | 29607 | 393216 | bf16 | PURE | FULL_SHARD | False | False | 760470528 |
+|  760m | 2048 | 8 | a100_40gb | 52.89 | 52.89 | 12 | 4 | 384 | 117 | 241389 | 30173 | 786432 | bf16 | PURE | FULL_SHARD | False | False | 760470528 |
+|  760m | 1024 | 8 | a100_40gb | 53.63 | 53.63 | 24 | 4 | 768 | 261 | 267376 | 33422 | 786432 | bf16 | PURE | FULL_SHARD | False | False | 758897664 |
+|  760m | 512 | 8 | a100_40gb | 53.47 | 53.47 | 48 | 4 | 1536 | 545 | 279504 | 34938 | 786432 | bf16 | PURE | FULL_SHARD | False | False | 758111232 |
+|  350m | 32768 | 8 | a100_40gb | 51.55 | 51.55 | 1 | 4 | 32 | 3 | 107329 | 13416 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 387442688 |
+|  350m | 16384 | 8 | a100_40gb | 51.78 | 51.78 | 2 | 4 | 64 | 11 | 183175 | 22896 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 370665472 |
+|  350m | 8192 | 8 | a100_40gb | 51.39 | 51.39 | 4 | 4 | 128 | 34 | 279466 | 34933 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 362276864 |
+|  350m | 4096 | 8 | a100_40gb | 50.38 | 50.38 | 8 | 4 | 256 | 91 | 374670 | 46833 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 358082560 |
+|  350m | 2048 | 128 | a100_40gb | 45.61 | 45.61 | 18 | 1 | 2304 | 3245 | 6647647 | 51934 | 4718592 | bf16 | PURE | FULL_SHARD | False | False | 355985408 |
+|  350m | 2048 | 64 | a100_40gb | 46.27 | 46.27 | 18 | 1 | 1152 | 1646 | 3372118 | 52689 | 2359296 | bf16 | PURE | FULL_SHARD | False | False | 355985408 |
+|  350m | 2048 | 32 | a100_40gb | 47.26 | 47.26 | 18 | 1 | 576 | 840 | 1721978 | 53811 | 1179648 | bf16 | PURE | FULL_SHARD | False | False | 355985408 |
+|  350m | 2048 | 16 | a100_40gb | 48.66 | 48.66 | 18 | 1 | 288 | 432 | 886622 | 55413 | 589824 | bf16 | PURE | FULL_SHARD | False | False | 355985408 |
+|  350m | 2048 | 8 | a100_40gb | 49.17 | 49.17 | 16 | 4 | 512 | 218 | 447963 | 55995 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 355985408 |
+|  350m | 1024 | 8 | a100_40gb | 48.73 | 48.73 | 32 | 4 | 1024 | 488 | 500184 | 62523 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 354936832 |
+|  350m | 512 | 8 | a100_40gb | 48.39 | 48.39 | 64 | 4 | 2048 | 1035 | 530277 | 66284 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 354412544 |
+|  125m | 32768 | 8 | a100_40gb | 47.27 | 47.27 | 1 | 4 | 32 | 7 | 261208 | 32651 | 1048576 | bf16 | PURE | FULL_SHARD | False | False | 148904448 |
+|  125m | 16384 | 8 | a100_40gb | 46.77 | 46.77 | 2 | 3 | 48 | 27 | 443876 | 55484 | 786432 | bf16 | PURE | FULL_SHARD | False | False | 136321536 |
+|  125m | 8192 | 8 | a100_40gb | 46.94 | 46.94 | 5 | 3 | 120 | 84 | 694868 | 86858 | 983040 | bf16 | PURE | FULL_SHARD | False | False | 130030080 |
+|  125m | 4096 | 8 | a100_40gb | 44.82 | 44.82 | 13 | 3 | 312 | 224 | 921297 | 115162 | 1277952 | bf16 | PURE | FULL_SHARD | False | False | 126884352 |
+|  125m | 2048 | 128 | a100_40gb | 38.86 | 38.86 | 26 | 1 | 3328 | 7746 | 15863837 | 123936 | 6815744 | bf16 | PURE | FULL_SHARD | False | False | 125311488 |
+|  125m | 2048 | 64 | a100_40gb | 39.27 | 39.27 | 26 | 1 | 1664 | 3913 | 8015010 | 125234 | 3407872 | bf16 | PURE | FULL_SHARD | False | False | 125311488 |
+|  125m | 2048 | 32 | a100_40gb | 39.86 | 39.86 | 26 | 1 | 832 | 1986 | 4067922 | 127122 | 1703936 | bf16 | PURE | FULL_SHARD | False | False | 125311488 |
+|  125m | 2048 | 16 | a100_40gb | 40.93 | 40.93 | 26 | 1 | 416 | 1019 | 2088560 | 130535 | 851968 | bf16 | PURE | FULL_SHARD | False | False | 125311488 |
+|  125m | 2048 | 8 | a100_40gb | 42.75 | 42.75 | 26 | 3 | 624 | 532 | 1090678 | 136334 | 1277952 | bf16 | PURE | FULL_SHARD | False | False | 125311488 |
+|  125m | 1024 | 8 | a100_40gb | 40.89 | 40.89 | 52 | 3 | 1248 | 1158 | 1186314 | 148289 | 1277952 | bf16 | PURE | FULL_SHARD | False | False | 124525056 |
+|  125m | 512 | 8 | a100_40gb | 40.26 | 40.26 | 104 | 3 | 2496 | 2448 | 1253886 | 156735 | 1277952 | bf16 | PURE | FULL_SHARD | False | False | 124131840 |

--- a/examples/llm/throughput/README.md
+++ b/examples/llm/throughput/README.md
@@ -67,7 +67,7 @@ This will run 8 configs for 12 steps to get throughput numbers. `python collect_
 
 Our microbatching engine enables microbatch sizes that do not divde Global Batchsize while being mathematically faithful to the global batch size. For example, a total batch size of 48, and a micro batch of 11, means we will accumulate gradients across microbatches of 11, 11, 11, 11, 4.
 
-#### TODO: Updated using torch 2.0
+#### TODO: Update tables with torch 2.0 after next Composer release
 
 ## A100 80GB
 

--- a/examples/llm/throughput/collect_results.py
+++ b/examples/llm/throughput/collect_results.py
@@ -231,11 +231,11 @@ def main(args):
             f.write(fmt.format(*fieldnames))
             f.write(fmt.format(*['---' for _ in fieldnames]))
             if args.print_results:
-                print(fmt.format(*fieldnames))
-                print(fmt.format(*['---' for _ in fieldnames]))
+                print(fmt.format(*fieldnames), end='')
+                print(fmt.format(*['---' for _ in fieldnames]), end='')
             for result in results:
                 if args.print_results:
-                    print(fmt.format(*result.values()))
+                    print(fmt.format(*result.values()), end='')
                 f.write(fmt.format(*result.values()))
     else:
         print('WARNING: No results parsed.')

--- a/examples/llm/throughput/collect_results.py
+++ b/examples/llm/throughput/collect_results.py
@@ -11,6 +11,17 @@ from mcli import sdk as msdk
 GPU_AVAILABLE_FLOPS = 312_000_000_000_000
 
 
+def str_to_bool(value):
+    # helper fn
+    if isinstance(value, bool):
+        return value
+    if value.lower() in {'false', 'f', '0', 'no', 'n'}:
+        return False
+    elif value.lower() in {'true', 't', '1', 'yes', 'y'}:
+        return True
+    raise ValueError(f'{value} is not a valid boolean value')
+
+
 def parse_args():
     parser = argparse.ArgumentParser(description="""
         Parse run configs to get MosaicGPT training throughput.
@@ -24,6 +35,12 @@ def parse_args():
                         '--save-path',
                         type=str,
                         default='benchmark_results')
+    parser.add_argument('-p',
+                        '--print-results',
+                        type=str_to_bool,
+                        nargs='?',
+                        const=True,
+                        default=False)
 
     return parser.parse_args()
 
@@ -34,7 +51,7 @@ def get_runs(args):
         runs = [r for r in runs if filter in r.name]
 
     def sort_key(r):
-        model_name = [s for s in r.name.split('-') if 'gpt' in s][0]
+        model_name = r.name.split('-')[2]
         num_gpu = r.config.gpu_num
         if model_name[-1] == 'm':
             model_name_size = 1e6
@@ -43,7 +60,7 @@ def get_runs(args):
         else:
             print(model_name)
             raise ValueError
-        model_size = int(model_name[3:-1])
+        model_size = int(model_name[:-1])
         return (model_name_size, model_size, r.config.parameters['max_seq_len'],
                 num_gpu, r.config.parameters['global_train_batch_size'])
 
@@ -88,7 +105,7 @@ def filter_runs(runs):
 def parse_run(run) -> Dict[str, Any]:
     n_params = micro_batchsize = throughput = -1
 
-    model_name = [s for s in run.name.split('-') if 'gpt' in s][0]
+    model_name = run.name.split('-')[2]
     gpu_num = run.config.gpu_num
     gpu_type = run.config.gpu_type
 
@@ -198,27 +215,32 @@ def main(args):
             print(f'{run.name=} not parsed')
             print(e)
 
-    csv_name = args.save_path + '.csv'
-    with open(csv_name, 'w') as f:
-        writer = csv.DictWriter(f, fieldnames=results[0].keys())
-        writer.writeheader()
-        for result in results:
-            writer.writerow(result)
+    if results:
+        csv_name = args.save_path + '.csv'
+        with open(csv_name, 'w') as f:
+            writer = csv.DictWriter(f, fieldnames=results[0].keys())
+            writer.writeheader()
+            for result in results:
+                writer.writerow(result)
 
-    md_name = args.save_path + '.md'
-    fieldnames = results[0].keys()
-    with open(md_name, 'w') as f:
-        fmt = '| ' + ' {} |' * len(fieldnames) + '\n'
+        md_name = args.save_path + '.md'
+        fieldnames = results[0].keys()
+        with open(md_name, 'w') as f:
+            fmt = '| ' + ' {} |' * len(fieldnames) + '\n'
 
-        f.write(fmt.format(*fieldnames))
-        f.write(fmt.format(*['---' for _ in fieldnames]))
-        for result in results:
-            f.write(fmt.format(*result.values()))
+            f.write(fmt.format(*fieldnames))
+            f.write(fmt.format(*['---' for _ in fieldnames]))
+            if args.print_results:
+                print(fmt.format(*fieldnames))
+                print(fmt.format(*['---' for _ in fieldnames]))
+            for result in results:
+                if args.print_results:
+                    print(fmt.format(*result.values()))
+                f.write(fmt.format(*result.values()))
+    else:
+        print('WARNING: No results parsed.')
 
 
 if __name__ == '__main__':
     args = parse_args()
     main(args)
-
-    from mcli.api.engine.engine import MAPIConnection
-    MAPIConnection.get_current_connection().close()

--- a/examples/llm/throughput/submit_benchmarks.py
+++ b/examples/llm/throughput/submit_benchmarks.py
@@ -7,8 +7,8 @@ import os
 
 import requests
 import yaml
-from mcli.sdk import RunConfig, create_run, get_clusters
 from mcli.models.run_config import SchedulingConfig
+from mcli.sdk import RunConfig, create_run, get_clusters
 
 
 def _get_cluster_info():
@@ -77,8 +77,7 @@ def parse_args():
         type=int,
         default=[11, 11],
         nargs=2,
-        help=
-        'exponent of seq lengths to be tested (default: [11, 11] = 2048)')
+        help='exponent of seq lengths to be tested (default: [11, 11] = 2048)')
     parser.add_argument(
         '-b',
         '--batch_size_exp',
@@ -116,10 +115,8 @@ def parse_args():
                         ],
                         nargs='+',
                         help='model sizes to test')
-    
-    parser.add_argument('--attn_impl',
-                        type=str,
-                        default='triton')
+
+    parser.add_argument('--attn_impl', type=str, default='triton')
 
     parser.add_argument('-c',
                         '--clusters',
@@ -161,9 +158,7 @@ def parse_args():
                         const=True,
                         default=True)
 
-    parser.add_argument('--priority',
-                        type=str,
-                        default='low')
+    parser.add_argument('--priority', type=str, default='low')
 
     parser.add_argument('--RUN',
                         type=str_to_bool,
@@ -183,7 +178,7 @@ def get_global_train_batch_sizes(max_seq_len, pows, batch_sizes=[]):
         # global batch size in tokens (defualt: .5M thru 8M)
         global_train_token_counts = [2**n for n in range(pows[0], pows[1] + 1)]
         batch_sizes += [t // max_seq_len for t in global_train_token_counts
-                      ]  # global batch size in samples
+                       ]  # global batch size in samples
     return batch_sizes
 
 
@@ -304,7 +299,7 @@ def mod_parameters(parameters,
     if fsdp_config_activation_checkpointing is not None:
         parameters['fsdp_config'][
             'activation_checkpointing'] = fsdp_config_activation_checkpointing
-        
+
     parameters['fsdp_config']['activation_checkpointing_reentrant'] = False
     parameters['fsdp_config']['limit_all_gathers'] = True
 
@@ -394,7 +389,8 @@ def run_config(config, args):
         global_train_batch_size,
         precision,
         fsdp_config_mixed_precision=args.fsdp_config_mixed_precision,
-        fsdp_config_activation_checkpointing=args.fsdp_config_activation_checkpointing,
+        fsdp_config_activation_checkpointing=args.
+        fsdp_config_activation_checkpointing,
         run_name=name,
         data_remote=args.data_remote,
         microbatch_size=microbatch_size,
@@ -402,21 +398,19 @@ def run_config(config, args):
         pad_vocab_multiple=args.pad_vocab_multiple)
 
     # Create run config mcli sdk/api
-    config = RunConfig(
-        run_name=name,
-        name=name,
-        gpu_type=gpu_type,
-        gpu_num=gpu_num,
-        cpus=None,
-        platform=None,
-        cluster=cluster,
-        image=args.image,
-        optimization_level=0,
-        integrations=integrations,
-        command=command,
-        parameters=parameters,
-        scheduling=SchedulingConfig(priority=args.priority)
-    )
+    config = RunConfig(run_name=name,
+                       name=name,
+                       gpu_type=gpu_type,
+                       gpu_num=gpu_num,
+                       cpus=None,
+                       platform=None,
+                       cluster=cluster,
+                       image=args.image,
+                       optimization_level=0,
+                       integrations=integrations,
+                       command=command,
+                       parameters=parameters,
+                       scheduling=SchedulingConfig(priority=args.priority))
 
     if args.RUN:
         # Create the run from a config
@@ -469,9 +463,11 @@ if __name__ == '__main__':
                         max_seq_len, args.batch_size_exp, args.batch_sizes)
                     if not global_train_batch_sizes and args.microbatch_size is not None:
                         accum = args.accum or 1
-                        global_train_batch_sizes = [accum * gpu_num * args.microbatch_size]
-                    
-                    for global_train_batch_size in global_train_batch_sizes:    
+                        global_train_batch_sizes = [
+                            accum * gpu_num * args.microbatch_size
+                        ]
+
+                    for global_train_batch_size in global_train_batch_sizes:
                         for precision in args.precisions:
                             for model_yaml in args.model_yamls:
 
@@ -480,7 +476,9 @@ if __name__ == '__main__':
                                                          gpu_type,
                                                          p_multiplier=4)
                                 if args.microbatch_size is not None:
-                                    run = run and run_check_dtms(gpu_num, args.microbatch_size, global_train_batch_size)
+                                    run = run and run_check_dtms(
+                                        gpu_num, args.microbatch_size,
+                                        global_train_batch_size)
 
                                 if run:
                                     config = (model_yaml, max_seq_len,

--- a/examples/llm/throughput/submit_benchmarks.py
+++ b/examples/llm/throughput/submit_benchmarks.py
@@ -8,6 +8,7 @@ import os
 import requests
 import yaml
 from mcli.sdk import RunConfig, create_run, get_clusters
+from mcli.models.run_config import SchedulingConfig
 
 
 def _get_cluster_info():
@@ -15,9 +16,9 @@ def _get_cluster_info():
     cluster_info = {}
 
     for cluster in clusters:
-        cluster_info[cluster.name] = [(ci.gpu_type.value, max(ci.gpu_nums))
+        cluster_info[cluster.name] = [(ci.gpu_type, max(ci.gpu_nums))
                                       for ci in cluster.cluster_instances
-                                      if ci.gpu_type.value is not None]
+                                      if ci.gpu_type is not None]
 
     return cluster_info
 
@@ -26,6 +27,7 @@ CLUSTER_INFO = _get_cluster_info()
 
 
 def str_to_bool(value):
+    # helper fn
     if isinstance(value, bool):
         return value
     if value.lower() in {'false', 'f', '0', 'no', 'n'}:
@@ -63,7 +65,7 @@ def parse_args():
                         choices=['bf16', 'fp16'])
     parser.add_argument('--fsdp_config_mixed_precision',
                         type=str,
-                        default='DEFAULT')
+                        default='PURE')
     parser.add_argument('--fsdp_config_activation_checkpointing',
                         type=str_to_bool,
                         nargs='?',
@@ -73,18 +75,31 @@ def parse_args():
         '-s',
         '--seq_len_exp',
         type=int,
-        default=[9, 14],
+        default=[11, 11],
         nargs=2,
         help=
-        'exponent of seq lengths to be tested (default: [9, 14] = 2^9 to 2^13)')
+        'exponent of seq lengths to be tested (default: [11, 11] = 2048)')
     parser.add_argument(
         '-b',
         '--batch_size_exp',
         type=int,
-        default=[23, 23],
+        default=None,
         nargs=2,
         help=
         'exponent of batch size (in tokens) to be tested (default: [19, 23] = 2^19 to 2^23)'
+    )
+    parser.add_argument(
+        '--batch_sizes',
+        type=int,
+        nargs='+',
+        default=[],
+        help='batch sizes to run.',
+    )
+    parser.add_argument(
+        '--accum',
+        type=int,
+        default=None,
+        help='batch sizes multiplier (accumulations before step).',
     )
     parser.add_argument('-m',
                         '--model_yamls',
@@ -101,6 +116,10 @@ def parse_args():
                         ],
                         nargs='+',
                         help='model sizes to test')
+    
+    parser.add_argument('--attn_impl',
+                        type=str,
+                        default='triton')
 
     parser.add_argument('-c',
                         '--clusters',
@@ -142,6 +161,10 @@ def parse_args():
                         const=True,
                         default=True)
 
+    parser.add_argument('--priority',
+                        type=str,
+                        default='low')
+
     parser.add_argument('--RUN',
                         type=str_to_bool,
                         nargs='?',
@@ -155,11 +178,13 @@ def get_max_seq_lens(pows=[9, 14]):
     return [2**n for n in range(pows[0], pows[1] + 1)]
 
 
-def get_global_train_batch_sizes(max_seq_len, pows=[19, 23]):
-    # global batch size in tokens (defualt: .5M thru 8M)
-    global_train_token_counts = [2**n for n in range(pows[0], pows[1] + 1)]
-    return [t // max_seq_len for t in global_train_token_counts
-           ]  # global batch size in samples
+def get_global_train_batch_sizes(max_seq_len, pows, batch_sizes=[]):
+    if pows:
+        # global batch size in tokens (defualt: .5M thru 8M)
+        global_train_token_counts = [2**n for n in range(pows[0], pows[1] + 1)]
+        batch_sizes += [t // max_seq_len for t in global_train_token_counts
+                      ]  # global batch size in samples
+    return batch_sizes
 
 
 def get_parameters(yaml_file):
@@ -239,9 +264,15 @@ def mod_parameters(parameters,
     else:
         parameters['train_loader']['dataset'][
             'split'] = 'train_small'  # for throughput testing purposes
+        parameters['eval_loader']['dataset'][
+            'split'] = 'val_small'  # for throughput testing purposes
     # set max_seq_len
     parameters['max_seq_len'] = max_seq_len
     parameters['model']['max_seq_len'] = max_seq_len
+
+    parameters['model']['attn_impl'] = args.attn_impl
+
+    parameters['model']['low_precision_layernorm'] = True
 
     # Pad vocab size to multiple of N for A100 perf
     if pad_vocab_multiple:
@@ -249,7 +280,7 @@ def mod_parameters(parameters,
         parameters['model']['vocab_size'] = math.ceil(
             vocab_size / pad_vocab_multiple) * pad_vocab_multiple
 
-    parameters['tokenizer']['args']['max_seq_len'] = max_seq_len
+    parameters['tokenizer']['kwargs']['model_max_length'] = max_seq_len
     parameters['train_loader']['dataset']['max_seq_len'] = max_seq_len
     parameters['eval_loader']['dataset']['max_seq_len'] = max_seq_len
 
@@ -273,6 +304,9 @@ def mod_parameters(parameters,
     if fsdp_config_activation_checkpointing is not None:
         parameters['fsdp_config'][
             'activation_checkpointing'] = fsdp_config_activation_checkpointing
+        
+    parameters['fsdp_config']['activation_checkpointing_reentrant'] = False
+    parameters['fsdp_config']['limit_all_gathers'] = True
 
     if wandb:
         # add wandb
@@ -327,10 +361,10 @@ def run_config(config, args):
         composer examples/llm/main.py /mnt/config/parameters.yaml
         """
     else:
-        command = """
+        command = f"""
         cd examples
 
-        python ../common/convert_dataset.py --dataset c4 --data_subset en --out_root ./my-copy-c4 --splits train_small val --concat_tokens 2048 --tokenizer gpt2 --eos_text '<|endoftext|>'
+        python examples/common/convert_dataset.py --dataset c4 --data_subset en --out_root ./my-copy-c4 --splits train_small val_small --concat_tokens {max_seq_len} --tokenizer gpt2 --eos_text '<|endoftext|>'
 
         composer examples/llm/main.py /mnt/config/parameters.yaml
         """
@@ -360,8 +394,7 @@ def run_config(config, args):
         global_train_batch_size,
         precision,
         fsdp_config_mixed_precision=args.fsdp_config_mixed_precision,
-        fsdp_config_activation_checkpointing=args.
-        fsdp_config_activation_checkpointing,
+        fsdp_config_activation_checkpointing=args.fsdp_config_activation_checkpointing,
         run_name=name,
         data_remote=args.data_remote,
         microbatch_size=microbatch_size,
@@ -382,11 +415,12 @@ def run_config(config, args):
         integrations=integrations,
         command=command,
         parameters=parameters,
+        scheduling=SchedulingConfig(priority=args.priority)
     )
 
     if args.RUN:
         # Create the run from a config
-        run = create_run(config)  # , _priority='low'
+        run = create_run(config)
         print(f'Launching run {run.name}')
     else:
         print(f'run = {name}')
@@ -412,18 +446,32 @@ def run_check_capacity(model_yaml, gpu_num, gpu_type, p_multiplier=16):
     return True
 
 
+def run_check_dtms(num_gpus, dtms, batch_size):
+    if num_gpus * dtms > batch_size:
+        print(
+            f'WARNING: Cannot run with {batch_size=} on {num_gpus=} with {dtms=} ({num_gpus*dtms=}).'
+        )
+        return False
+    return True
+
+
 if __name__ == '__main__':
     args = parse_args()
 
     n_jobs = 0
     for max_seq_len in get_max_seq_lens(args.seq_len_exp):
-        for global_train_batch_size in get_global_train_batch_sizes(
-                max_seq_len, args.batch_size_exp):
-            for cluster in args.clusters:
-                for gpu_type in get_cluster_gpu_types(cluster):
-                    ng_lim = get_valid_gpu_lim(cluster, gpu_type)
-                    _gpu_nums = [ng for ng in args.gpu_nums if ng <= ng_lim]
-                    for gpu_num in _gpu_nums:
+        for cluster in args.clusters:
+            for gpu_type in get_cluster_gpu_types(cluster):
+                ng_lim = get_valid_gpu_lim(cluster, gpu_type)
+                _gpu_nums = [ng for ng in args.gpu_nums if ng <= ng_lim]
+                for gpu_num in _gpu_nums:
+                    global_train_batch_sizes = get_global_train_batch_sizes(
+                        max_seq_len, args.batch_size_exp, args.batch_sizes)
+                    if not global_train_batch_sizes and args.microbatch_size is not None:
+                        accum = args.accum or 1
+                        global_train_batch_sizes = [accum * gpu_num * args.microbatch_size]
+                    
+                    for global_train_batch_size in global_train_batch_sizes:    
                         for precision in args.precisions:
                             for model_yaml in args.model_yamls:
 
@@ -431,6 +479,9 @@ if __name__ == '__main__':
                                                          gpu_num,
                                                          gpu_type,
                                                          p_multiplier=4)
+                                if args.microbatch_size is not None:
+                                    run = run and run_check_dtms(gpu_num, args.microbatch_size, global_train_batch_size)
+
                                 if run:
                                     config = (model_yaml, max_seq_len,
                                               global_train_batch_size, cluster,

--- a/examples/llm/throughput/sweep.sh
+++ b/examples/llm/throughput/sweep.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-PROJECT=PROJECT_NAME
+PROJECT="tput"
 GIT_COMMIT="release/v0.0.4"
 IMAGE="mosaicml/pytorch:1.13.1_cu117-python3.10-ubuntu20.04"
 CLUSTER_80GB=YOUR_CLUSTER_80GB
+CLUSTER_40GB=YOUR_CLUSTER_40GB
 
-# SCALE SEQUENCE LENGTH
+
+# A100 80GB
 
 # seqlen 2048
 python submit_benchmarks.py --project $PROJECT -m 125m.yaml -g 8 --microbatch_size  32 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
@@ -16,6 +18,24 @@ python submit_benchmarks.py --project $PROJECT -m   3b.yaml -g 8 --microbatch_si
 python submit_benchmarks.py --project $PROJECT -m   7b.yaml -g 8 --microbatch_size  32 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
 python submit_benchmarks.py --project $PROJECT -m  13b.yaml -g 8 --microbatch_size  20 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
 python submit_benchmarks.py --project $PROJECT -m  30b.yaml -g 8 --microbatch_size   3 --accum 21 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+
+# INCREASE GPU COUNT
+python submit_benchmarks.py --project $PROJECT -m 125m.yaml -g 16 32 64 --microbatch_size 32 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m 350m.yaml -g 16 32 64 --microbatch_size 32 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m 760m.yaml -g 16 32 64 --microbatch_size 24 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m   1b.yaml -g 16 32 64 --microbatch_size 20 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m   3b.yaml -g 16       --microbatch_size 10 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN --fsdp_config_activation_checkpointing false
+python submit_benchmarks.py --project $PROJECT -m   7b.yaml -g 16 32 64 --microbatch_size 32 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m  13b.yaml -g 16       --microbatch_size 24 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m  30b.yaml -g 16       --microbatch_size 10 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m   3b.yaml -g    32 64 --microbatch_size 12 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN --fsdp_config_activation_checkpointing false
+python submit_benchmarks.py --project $PROJECT -m  13b.yaml -g    32 64 --microbatch_size 32 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m  30b.yaml -g    32    --microbatch_size 14 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m  70b.yaml -g    32    --microbatch_size  2 --accum 16 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m  30b.yaml -g       64 --microbatch_size 16 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m  70b.yaml -g       64 --microbatch_size  8 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+
+# SCALE SEQUENCE LENGTH
 # seqlen 512
 python submit_benchmarks.py --project $PROJECT -m 125m.yaml -g 8 --microbatch_size 128 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s  9  9 --RUN
 python submit_benchmarks.py --project $PROJECT -m 350m.yaml -g 8 --microbatch_size 128 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s  9  9 --RUN
@@ -76,22 +96,79 @@ python submit_benchmarks.py --project $PROJECT -m   1b.yaml -g 8 --microbatch_si
 python submit_benchmarks.py --project $PROJECT -m   3b.yaml -g 8 --microbatch_size   1 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 16 16 --RUN
 python submit_benchmarks.py --project $PROJECT -m   7b.yaml -g 8 --microbatch_size   1 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 16 16 --RUN
 
-# SCALE GPU COUNT
+
+# A100 40GB
 
 # seqlen 2048
-python submit_benchmarks.py --project $PROJECT -m 125m.yaml -g 16 32 64 --microbatch_size 32 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
-python submit_benchmarks.py --project $PROJECT -m 350m.yaml -g 16 32 64 --microbatch_size 32 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
-python submit_benchmarks.py --project $PROJECT -m 760m.yaml -g 16 32 64 --microbatch_size 24 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
-python submit_benchmarks.py --project $PROJECT -m   1b.yaml -g 16 32 64 --microbatch_size 20 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
-python submit_benchmarks.py --project $PROJECT -m   3b.yaml -g 16       --microbatch_size 10 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN --fsdp_config_activation_checkpointing false
-python submit_benchmarks.py --project $PROJECT -m   7b.yaml -g 16 32 64 --microbatch_size 32 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
-python submit_benchmarks.py --project $PROJECT -m  13b.yaml -g 16       --microbatch_size 24 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
-python submit_benchmarks.py --project $PROJECT -m  30b.yaml -g 16       --microbatch_size 10 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m 125m.yaml -g 8 --microbatch_size  26 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m 350m.yaml -g 8 --microbatch_size  16 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m 760m.yaml -g 8 --microbatch_size  12 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m   1b.yaml -g 8 --microbatch_size   8 --accum  8 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m   3b.yaml -g 8 --microbatch_size   5 --accum  8 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 11 11 --RUN --fsdp_config_activation_checkpointing false
+python submit_benchmarks.py --project $PROJECT -m   7b.yaml -g 8 --microbatch_size  16 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m  13b.yaml -g 8 --microbatch_size   4 --accum 16 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 11 11 --RUN
 
-python submit_benchmarks.py --project $PROJECT -m   3b.yaml -g    32 64 --microbatch_size 12 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN --fsdp_config_activation_checkpointing false
-python submit_benchmarks.py --project $PROJECT -m  13b.yaml -g    32 64 --microbatch_size 32 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
-python submit_benchmarks.py --project $PROJECT -m  30b.yaml -g    32    --microbatch_size 14 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
-python submit_benchmarks.py --project $PROJECT -m  70b.yaml -g    32    --microbatch_size  2 --accum 16 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+# INCREASE GPU COUNT
+python submit_benchmarks.py --project $PROJECT -m 125m.yaml -g 16 32 64 128 --microbatch_size  26 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m 350m.yaml -g 16 32 64 128 --microbatch_size  18 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m 760m.yaml -g 16 32 64 128 --microbatch_size  12 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m   1b.yaml -g 16           --microbatch_size   8 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m   3b.yaml -g 16           --microbatch_size   5 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 11 11 --RUN --fsdp_config_activation_checkpointing false
+python submit_benchmarks.py --project $PROJECT -m   7b.yaml -g 16           --microbatch_size  16 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m  13b.yaml -g 16           --microbatch_size  10 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m   1b.yaml -g    32 64 128 --microbatch_size  10 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m   3b.yaml -g    32 64 128 --microbatch_size   6 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 11 11 --RUN --fsdp_config_activation_checkpointing false
+python submit_benchmarks.py --project $PROJECT -m   7b.yaml -g    32 64 128 --microbatch_size  18 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m  13b.yaml -g    32        --microbatch_size  14 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m  30b.yaml -g    32        --microbatch_size   4 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m  13b.yaml -g       64 128 --microbatch_size  16 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m  70b.yaml -g       64     --microbatch_size   2 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m  30b.yaml -g          128 --microbatch_size   6 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m  70b.yaml -g          128 --microbatch_size   4 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 11 11 --RUN
 
-python submit_benchmarks.py --project $PROJECT -m  30b.yaml -g       64 --microbatch_size 16 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
-python submit_benchmarks.py --project $PROJECT -m  70b.yaml -g       64 --microbatch_size  8 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+# SCALE SEQUENCE LENGTH
+# seqlen 512
+python submit_benchmarks.py --project $PROJECT -m 125m.yaml -g 8 --microbatch_size 104 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s  9  9 --RUN
+python submit_benchmarks.py --project $PROJECT -m 350m.yaml -g 8 --microbatch_size  64 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s  9  9 --RUN
+python submit_benchmarks.py --project $PROJECT -m 760m.yaml -g 8 --microbatch_size  48 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s  9  9 --RUN
+python submit_benchmarks.py --project $PROJECT -m   1b.yaml -g 8 --microbatch_size  32 --accum  8 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s  9  9 --RUN
+python submit_benchmarks.py --project $PROJECT -m   3b.yaml -g 8 --microbatch_size  20 --accum  8 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s  9  9 --RUN --fsdp_config_activation_checkpointing false
+python submit_benchmarks.py --project $PROJECT -m   7b.yaml -g 8 --microbatch_size  56 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s  9  9 --RUN
+python submit_benchmarks.py --project $PROJECT -m  13b.yaml -g 8 --microbatch_size  16 --accum 16 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s  9  9 --RUN
+# seqlen 1024
+python submit_benchmarks.py --project $PROJECT -m 125m.yaml -g 8 --microbatch_size  52 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 10 10 --RUN
+python submit_benchmarks.py --project $PROJECT -m 350m.yaml -g 8 --microbatch_size  32 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 10 10 --RUN
+python submit_benchmarks.py --project $PROJECT -m 760m.yaml -g 8 --microbatch_size  24 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 10 10 --RUN
+python submit_benchmarks.py --project $PROJECT -m   1b.yaml -g 8 --microbatch_size  16 --accum  8 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 10 10 --RUN
+python submit_benchmarks.py --project $PROJECT -m   3b.yaml -g 8 --microbatch_size  10 --accum  8 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 10 10 --RUN --fsdp_config_activation_checkpointing false
+python submit_benchmarks.py --project $PROJECT -m   7b.yaml -g 8 --microbatch_size  28 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 10 10 --RUN
+python submit_benchmarks.py --project $PROJECT -m  13b.yaml -g 8 --microbatch_size   8 --accum 16 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 10 10 --RUN
+# seqlen 4096
+python submit_benchmarks.py --project $PROJECT -m 125m.yaml -g 8 --microbatch_size  13 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 12 12 --RUN
+python submit_benchmarks.py --project $PROJECT -m 350m.yaml -g 8 --microbatch_size   8 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 12 12 --RUN
+python submit_benchmarks.py --project $PROJECT -m 760m.yaml -g 8 --microbatch_size   6 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 12 12 --RUN
+python submit_benchmarks.py --project $PROJECT -m   1b.yaml -g 8 --microbatch_size   4 --accum  8 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 12 12 --RUN
+python submit_benchmarks.py --project $PROJECT -m   3b.yaml -g 8 --microbatch_size   2 --accum  8 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 12 12 --RUN --fsdp_config_activation_checkpointing false
+python submit_benchmarks.py --project $PROJECT -m   7b.yaml -g 8 --microbatch_size   8 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 12 12 --RUN
+python submit_benchmarks.py --project $PROJECT -m  13b.yaml -g 8 --microbatch_size   2 --accum 16 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 12 12 --RUN
+# seqlen 8192
+python submit_benchmarks.py --project $PROJECT -m 125m.yaml -g 8 --microbatch_size   5 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 13 13 --RUN
+python submit_benchmarks.py --project $PROJECT -m 350m.yaml -g 8 --microbatch_size   4 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 13 13 --RUN
+python submit_benchmarks.py --project $PROJECT -m 760m.yaml -g 8 --microbatch_size   3 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 13 13 --RUN
+python submit_benchmarks.py --project $PROJECT -m   1b.yaml -g 8 --microbatch_size   2 --accum  8 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 13 13 --RUN
+python submit_benchmarks.py --project $PROJECT -m   3b.yaml -g 8 --microbatch_size   1 --accum  8 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 13 13 --RUN --fsdp_config_activation_checkpointing false
+python submit_benchmarks.py --project $PROJECT -m   7b.yaml -g 8 --microbatch_size   3 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 13 13 --RUN
+python submit_benchmarks.py --project $PROJECT -m  13b.yaml -g 8 --microbatch_size   1 --accum 16 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 13 13 --RUN
+# seqlen 16384
+python submit_benchmarks.py --project $PROJECT -m 125m.yaml -g 8 --microbatch_size   2 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 14 14 --RUN
+python submit_benchmarks.py --project $PROJECT -m 350m.yaml -g 8 --microbatch_size   2 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 14 14 --RUN
+python submit_benchmarks.py --project $PROJECT -m 760m.yaml -g 8 --microbatch_size   1 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 14 14 --RUN
+python submit_benchmarks.py --project $PROJECT -m   1b.yaml -g 8 --microbatch_size   1 --accum  8 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 14 14 --RUN
+python submit_benchmarks.py --project $PROJECT -m   3b.yaml -g 8 --microbatch_size   2 --accum  8 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 14 14 --RUN
+python submit_benchmarks.py --project $PROJECT -m   7b.yaml -g 8 --microbatch_size   1 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 14 14 --RUN
+# seqlen 32768
+python submit_benchmarks.py --project $PROJECT -m 125m.yaml -g 8 --microbatch_size   1 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 15 15 --RUN
+python submit_benchmarks.py --project $PROJECT -m 350m.yaml -g 8 --microbatch_size   1 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 15 15 --RUN
+python submit_benchmarks.py --project $PROJECT -m 760m.yaml -g 8 --microbatch_size   1 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 15 15 --RUN --fsdp_config_activation_checkpointing true
+python submit_benchmarks.py --project $PROJECT -m   1b.yaml -g 8 --microbatch_size   1 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 15 15 --RUN --fsdp_config_activation_checkpointing true
+python submit_benchmarks.py --project $PROJECT -m   3b.yaml -g 8 --microbatch_size   1 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_40gb --cluster $CLUSTER_40GB -s 15 15 --RUN

--- a/examples/llm/throughput/sweep.sh
+++ b/examples/llm/throughput/sweep.sh
@@ -1,28 +1,97 @@
 #!/bin/bash
 
-PROJECT=YOUR_PROJECT
-GIT_COMMIT=YOUR_GIT_COMMIT
-CLUSTER_40GB=YOUR_CLUSTER_40GB
-CLUSTER_80GB=YOUR_CLUSTER_80GB
+PROJECT=PROJECT_NAME
+GIT_COMMIT="release/v0.0.4"
 IMAGE="mosaicml/pytorch:1.13.1_cu117-python3.10-ubuntu20.04"
+CLUSTER_80GB=YOUR_CLUSTER_80GB
 
+# SCALE SEQUENCE LENGTH
 
-# 40GB
-# python submit_benchmarks.py --project $PROJECT -s 11 11 -b 19 22 -m 125m.yaml -g 8 16 32 64 --image $IMAGE --git_commit $GIT_COMMIT --pad_vocab_multiple 16 --gpu_type a100_40gb --cluster $CLUSTER_40GB --RUN --microbatch_size 16
-# python submit_benchmarks.py --project $PROJECT -s 11 11 -b 19 22 -m 350m.yaml -g 8 16 32 64 --image $IMAGE --git_commit $GIT_COMMIT --pad_vocab_multiple 16 --gpu_type a100_40gb --cluster $CLUSTER_40GB --RUN --microbatch_size 8
-# python submit_benchmarks.py --project $PROJECT -s 11 11 -b 19 22 -m 760m.yaml -g 8 16 32 64 --image $IMAGE --git_commit $GIT_COMMIT --pad_vocab_multiple 16 --gpu_type a100_40gb --cluster $CLUSTER_40GB --RUN --microbatch_size 6
-# python submit_benchmarks.py --project $PROJECT -s 11 11 -b 19 22 -m 1b.yaml -g 8 16 32 64 --image $IMAGE --git_commit $GIT_COMMIT --pad_vocab_multiple 16 --gpu_type a100_40gb --cluster $CLUSTER_40GB --RUN --microbatch_size 4
-# python submit_benchmarks.py --project $PROJECT -s 11 11 -b 19 22 -m 3b.yaml -g 8 16 32 64 --image $IMAGE --git_commit $GIT_COMMIT --pad_vocab_multiple 16 --gpu_type a100_40gb --cluster $CLUSTER_40GB --RUN --microbatch_size 14
-# python submit_benchmarks.py --project $PROJECT -s 11 11 -b 19 22 -m 7b.yaml -g 8 --image $IMAGE --git_commit $GIT_COMMIT --pad_vocab_multiple 16 --gpu_type a100_40gb --cluster $CLUSTER_40GB --RUN --microbatch_size 6
-# python submit_benchmarks.py --project $PROJECT -s 11 11 -b 19 22 -m 7b.yaml -g 16 32 64 --image $IMAGE --git_commit $GIT_COMMIT --pad_vocab_multiple 16 --gpu_type a100_40gb --cluster $CLUSTER_40GB --RUN --microbatch_size 8
+# seqlen 2048
+python submit_benchmarks.py --project $PROJECT -m 125m.yaml -g 8 --microbatch_size  32 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m 350m.yaml -g 8 --microbatch_size  32 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m 760m.yaml -g 8 --microbatch_size  24 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m   1b.yaml -g 8 --microbatch_size  14 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m   3b.yaml -g 8 --microbatch_size  10 --accum  6 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN --fsdp_config_activation_checkpointing false
+python submit_benchmarks.py --project $PROJECT -m   7b.yaml -g 8 --microbatch_size  32 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m  13b.yaml -g 8 --microbatch_size  20 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m  30b.yaml -g 8 --microbatch_size   3 --accum 21 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+# seqlen 512
+python submit_benchmarks.py --project $PROJECT -m 125m.yaml -g 8 --microbatch_size 128 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s  9  9 --RUN
+python submit_benchmarks.py --project $PROJECT -m 350m.yaml -g 8 --microbatch_size 128 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s  9  9 --RUN
+python submit_benchmarks.py --project $PROJECT -m 760m.yaml -g 8 --microbatch_size  96 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s  9  9 --RUN
+python submit_benchmarks.py --project $PROJECT -m   1b.yaml -g 8 --microbatch_size  56 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s  9  9 --RUN
+python submit_benchmarks.py --project $PROJECT -m   3b.yaml -g 8 --microbatch_size  40 --accum  6 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s  9  9 --RUN --fsdp_config_activation_checkpointing false
+python submit_benchmarks.py --project $PROJECT -m   7b.yaml -g 8 --microbatch_size 128 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s  9  9 --RUN
+python submit_benchmarks.py --project $PROJECT -m  13b.yaml -g 8 --microbatch_size  80 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s  9  9 --RUN
+python submit_benchmarks.py --project $PROJECT -m  30b.yaml -g 8 --microbatch_size  12 --accum 21 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s  9  9 --RUN
+# seqlen 1024
+python submit_benchmarks.py --project $PROJECT -m 125m.yaml -g 8 --microbatch_size  64 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 10 10 --RUN
+python submit_benchmarks.py --project $PROJECT -m 350m.yaml -g 8 --microbatch_size  64 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 10 10 --RUN
+python submit_benchmarks.py --project $PROJECT -m 760m.yaml -g 8 --microbatch_size  48 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 10 10 --RUN
+python submit_benchmarks.py --project $PROJECT -m   1b.yaml -g 8 --microbatch_size  18 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 10 10 --RUN
+python submit_benchmarks.py --project $PROJECT -m   3b.yaml -g 8 --microbatch_size  20 --accum  6 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 10 10 --RUN --fsdp_config_activation_checkpointing false
+python submit_benchmarks.py --project $PROJECT -m   7b.yaml -g 8 --microbatch_size  64 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 10 10 --RUN
+python submit_benchmarks.py --project $PROJECT -m  13b.yaml -g 8 --microbatch_size  40 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 10 10 --RUN
+python submit_benchmarks.py --project $PROJECT -m  30b.yaml -g 8 --microbatch_size   6 --accum 21 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 10 10 --RUN
+# seqlen 4096
+python submit_benchmarks.py --project $PROJECT -m 125m.yaml -g 8 --microbatch_size  16 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 12 12 --RUN
+python submit_benchmarks.py --project $PROJECT -m 350m.yaml -g 8 --microbatch_size  16 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 12 12 --RUN
+python submit_benchmarks.py --project $PROJECT -m 760m.yaml -g 8 --microbatch_size  12 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 12 12 --RUN
+python submit_benchmarks.py --project $PROJECT -m   1b.yaml -g 8 --microbatch_size   7 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 12 12 --RUN
+python submit_benchmarks.py --project $PROJECT -m   3b.yaml -g 8 --microbatch_size   5 --accum  6 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 12 12 --RUN --fsdp_config_activation_checkpointing false
+python submit_benchmarks.py --project $PROJECT -m   7b.yaml -g 8 --microbatch_size  16 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 12 12 --RUN
+python submit_benchmarks.py --project $PROJECT -m  13b.yaml -g 8 --microbatch_size  10 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 12 12 --RUN
+python submit_benchmarks.py --project $PROJECT -m  30b.yaml -g 8 --microbatch_size   1 --accum 21 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 12 12 --RUN
+# seqlen 8192
+python submit_benchmarks.py --project $PROJECT -m 125m.yaml -g 8 --microbatch_size   8 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 13 13 --RUN
+python submit_benchmarks.py --project $PROJECT -m 350m.yaml -g 8 --microbatch_size   8 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 13 13 --RUN
+python submit_benchmarks.py --project $PROJECT -m 760m.yaml -g 8 --microbatch_size   6 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 13 13 --RUN
+python submit_benchmarks.py --project $PROJECT -m   1b.yaml -g 8 --microbatch_size   3 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 13 13 --RUN
+python submit_benchmarks.py --project $PROJECT -m   3b.yaml -g 8 --microbatch_size   3 --accum  6 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 13 13 --RUN --fsdp_config_activation_checkpointing false
+python submit_benchmarks.py --project $PROJECT -m   7b.yaml -g 8 --microbatch_size   8 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 13 13 --RUN
+python submit_benchmarks.py --project $PROJECT -m  13b.yaml -g 8 --microbatch_size   5 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 13 13 --RUN
+python submit_benchmarks.py --project $PROJECT -m  30b.yaml -g 8 --microbatch_size   1 --accum 21 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 13 13 --RUN
+# seqlen 16384
+python submit_benchmarks.py --project $PROJECT -m 125m.yaml -g 8 --microbatch_size   4 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 14 14 --RUN
+python submit_benchmarks.py --project $PROJECT -m 350m.yaml -g 8 --microbatch_size   4 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 14 14 --RUN
+python submit_benchmarks.py --project $PROJECT -m 760m.yaml -g 8 --microbatch_size   3 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 14 14 --RUN
+python submit_benchmarks.py --project $PROJECT -m   1b.yaml -g 8 --microbatch_size   2 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 14 14 --RUN
+python submit_benchmarks.py --project $PROJECT -m   3b.yaml -g 8 --microbatch_size   1 --accum  6 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 14 14 --RUN --fsdp_config_activation_checkpointing false
+python submit_benchmarks.py --project $PROJECT -m   7b.yaml -g 8 --microbatch_size   4 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 14 14 --RUN
+python submit_benchmarks.py --project $PROJECT -m  13b.yaml -g 8 --microbatch_size   3 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 14 14 --RUN
+# seqlen 32768
+python submit_benchmarks.py --project $PROJECT -m 125m.yaml -g 8 --microbatch_size   2 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 15 15 --RUN
+python submit_benchmarks.py --project $PROJECT -m 350m.yaml -g 8 --microbatch_size   2 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 15 15 --RUN
+python submit_benchmarks.py --project $PROJECT -m 760m.yaml -g 8 --microbatch_size   1 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 15 15 --RUN
+python submit_benchmarks.py --project $PROJECT -m   1b.yaml -g 8 --microbatch_size   1 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 15 15 --RUN
+python submit_benchmarks.py --project $PROJECT -m   3b.yaml -g 8 --microbatch_size   3 --accum  6 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 15 15 --RUN
+python submit_benchmarks.py --project $PROJECT -m   7b.yaml -g 8 --microbatch_size   2 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 15 15 --RUN
+python submit_benchmarks.py --project $PROJECT -m  13b.yaml -g 8 --microbatch_size   1 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 15 15 --RUN
+# seqlen 65536
+python submit_benchmarks.py --project $PROJECT -m 125m.yaml -g 8 --microbatch_size   1 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 16 16 --RUN
+python submit_benchmarks.py --project $PROJECT -m 350m.yaml -g 8 --microbatch_size   1 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 16 16 --RUN
+python submit_benchmarks.py --project $PROJECT -m 760m.yaml -g 8 --microbatch_size   1 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 16 16 --RUN --fsdp_config_activation_checkpointing true
+python submit_benchmarks.py --project $PROJECT -m   1b.yaml -g 8 --microbatch_size   1 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 16 16 --RUN --fsdp_config_activation_checkpointing true
+python submit_benchmarks.py --project $PROJECT -m   3b.yaml -g 8 --microbatch_size   1 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 16 16 --RUN
+python submit_benchmarks.py --project $PROJECT -m   7b.yaml -g 8 --microbatch_size   1 --accum  2 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 16 16 --RUN
 
+# SCALE GPU COUNT
 
-# 80GB
-# python submit_benchmarks.py --project $PROJECT -s 11 11 -b 19 22 -m 125m.yaml -g 8 16 --image $IMAGE --git_commit $GIT_COMMIT --pad_vocab_multiple 16 --gpu_type a100_80gb --cluster $CLUSTER_80GB --RUN --microbatch_size 32
-# python submit_benchmarks.py --project $PROJECT -s 11 11 -b 19 19 -m 350m.yaml -g 8 16 --image $IMAGE --git_commit $GIT_COMMIT --pad_vocab_multiple 16 --gpu_type a100_80gb --cluster $CLUSTER_80GB --RUN --microbatch_size 16
-# python submit_benchmarks.py --project $PROJECT -s 11 11 -b 19 19 -m 760m.yaml -g 8 16 --image $IMAGE --git_commit $GIT_COMMIT --pad_vocab_multiple 16 --gpu_type a100_80gb --cluster $CLUSTER_80GB --RUN --microbatch_size 12
-# python submit_benchmarks.py --project $PROJECT -s 11 11 -b 19 19 -m 1b.yaml -g 8 16 --image $IMAGE --git_commit $GIT_COMMIT --pad_vocab_multiple 16 --gpu_type a100_80gb --cluster $CLUSTER_80GB --RUN --microbatch_size 10
-# python submit_benchmarks.py --project $PROJECT -s 11 11 -b 19 19 -m 3b.yaml -g 8 16 --image $IMAGE --git_commit $GIT_COMMIT --pad_vocab_multiple 16 --gpu_type a100_80gb --cluster $CLUSTER_80GB --RUN --microbatch_size 6 --fsdp_config_activation_checkpointing false
-# python submit_benchmarks.py --project $PROJECT -s 11 11 -b 19 19 -m 7b.yaml -g 8 16 --image $IMAGE --git_commit $GIT_COMMIT --pad_vocab_multiple 16 --gpu_type a100_80gb --cluster $CLUSTER_80GB --RUN --microbatch_size 20
-# python submit_benchmarks.py --project $PROJECT -s 11 11 -b 19 19 -m 13b.yaml -g 8 16 --image $IMAGE --git_commit $GIT_COMMIT --pad_vocab_multiple 16 --gpu_type a100_80gb --cluster $CLUSTER_80GB --RUN --microbatch_size 12
-# python submit_benchmarks.py --project $PROJECT -s 11 11 -b 19 22 -m 13b.yaml -g 16 --image $IMAGE --git_commit $GIT_COMMIT --pad_vocab_multiple 16 --gpu_type a100_80gb --cluster $CLUSTER_80GB --RUN --microbatch_size 16
+# seqlen 2048
+python submit_benchmarks.py --project $PROJECT -m 125m.yaml -g 16 32 64 --microbatch_size 32 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m 350m.yaml -g 16 32 64 --microbatch_size 32 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m 760m.yaml -g 16 32 64 --microbatch_size 24 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m   1b.yaml -g 16 32 64 --microbatch_size 20 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m   3b.yaml -g 16       --microbatch_size 10 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN --fsdp_config_activation_checkpointing false
+python submit_benchmarks.py --project $PROJECT -m   7b.yaml -g 16 32 64 --microbatch_size 32 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m  13b.yaml -g 16       --microbatch_size 24 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m  30b.yaml -g 16       --microbatch_size 10 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+
+python submit_benchmarks.py --project $PROJECT -m   3b.yaml -g    32 64 --microbatch_size 12 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN --fsdp_config_activation_checkpointing false
+python submit_benchmarks.py --project $PROJECT -m  13b.yaml -g    32 64 --microbatch_size 32 --accum  1 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m  30b.yaml -g    32    --microbatch_size 14 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m  70b.yaml -g    32    --microbatch_size  2 --accum 16 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+
+python submit_benchmarks.py --project $PROJECT -m  30b.yaml -g       64 --microbatch_size 16 --accum  3 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN
+python submit_benchmarks.py --project $PROJECT -m  70b.yaml -g       64 --microbatch_size  8 --accum  4 --image $IMAGE --git_commit $GIT_COMMIT --gpu_type a100_80gb --cluster $CLUSTER_80GB -s 11 11 --RUN


### PR DESCRIPTION
This PR updates the [GPT throughput tables](https://github.com/vchiley/examples/tree/throughput_updt/examples/llm/throughput).

Note: since I branched from `main`, there are a few "extra" file which are already in relv04 branch. ignore