### PR TITLE
Upgrade to Composer 0.13.3

### DIFF
--- a/examples/llm/requirements.txt
+++ b/examples/llm/requirements.txt
@@ -1,6 +1,6 @@
 torch==1.13.1
 einops==0.5.0
-mosaicml==0.13.2
+mosaicml==0.13.3
 mosaicml-streaming==0.3.0
 flash-attn==0.2.8
 mosaicml-cli>=0.2.32,<1


### PR DESCRIPTION
This is a hotfix release that allows sentencepiece tokenizers to be used.

- [ ] Test training MosaicGPT with a sentencepiece tokenizer like LlamaTokenizer (https://huggingface.co/docs/transformers/main/model_doc/llama#transformers.LlamaTokenizer)