### PR TITLE
make LlamaTokenizer work for tokenizer bakeoff

### DIFF
--- a/examples/common/builders.py
+++ b/examples/common/builders.py
@@ -17,9 +17,11 @@ from composer.optim.scheduler import (ConstantWithWarmupScheduler,
                                       LinearWithWarmupScheduler)
 
 from examples.common.fdiff import FDiffMetrics
-from examples.common.optim import DecoupledLionW, DecoupledClipLion, DecoupledAdaLRLion
-from examples.common.text_data import build_text_dataloader
+from examples.common.generate_callback import Generate
+from examples.common.optim import (DecoupledAdaLRLion, DecoupledClipLion,
+                                   DecoupledLionW)
 from examples.common.resumption_callbacks import GlobalLRScaling, LayerFreezing
+from examples.common.text_data import build_text_dataloader
 
 
 def build_callback(name, kwargs):
@@ -40,6 +42,9 @@ def build_callback(name, kwargs):
             'log_optimizer_metrics', True),)
     elif name == 'health_checker':
         return HealthChecker(**kwargs)
+    elif name == 'generate_callback':
+        prompts = kwargs.pop('prompts')
+        return Generate(prompts=list(prompts), **kwargs)
     elif name == 'global_lr_scaling':
         return GlobalLRScaling(**kwargs)
     elif name == 'layer_freezing':
@@ -84,19 +89,19 @@ def build_optimizer(cfg, model):
                               weight_decay=cfg.weight_decay)
     elif cfg.name == 'clip_lion':
         return DecoupledClipLion(model.parameters(),
-                        lr=cfg.lr,
-                        betas=cfg.betas,
-                        weight_decay=cfg.weight_decay,
-                        outlier_threshold=cfg.outlier_threshold)
+                                 lr=cfg.lr,
+                                 betas=cfg.betas,
+                                 weight_decay=cfg.weight_decay,
+                                 outlier_threshold=cfg.outlier_threshold)
     elif cfg.name == 'adalr_lion':
         return DecoupledAdaLRLion(model.parameters(),
-                         lr=cfg.lr,
-                         betas=cfg.betas,
-                         weight_decay=cfg.weight_decay,
-                         outlier_threshold=cfg.outlier_threshold,
-                         timeout=cfg.timeout,
-                         lr_penalty=cfg.lr_penalty,
-                         min_scale=cfg.min_scale)
+                                  lr=cfg.lr,
+                                  betas=cfg.betas,
+                                  weight_decay=cfg.weight_decay,
+                                  outlier_threshold=cfg.outlier_threshold,
+                                  timeout=cfg.timeout,
+                                  lr_penalty=cfg.lr_penalty,
+                                  min_scale=cfg.min_scale)
     else:
         raise ValueError(f'Not sure how to build optimizer: {cfg.name}')
 

--- a/examples/common/convert_dataset.py
+++ b/examples/common/convert_dataset.py
@@ -17,6 +17,14 @@ from torch.utils.data import DataLoader, IterableDataset, get_worker_info
 from tqdm import tqdm
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
+try:
+    from examples.llm.src.models.utils import make_llama_work
+    make_llama_work()
+except ImportError:
+    import warnings
+    warnings.warn('Couldn\'t make Llama/Custom SentencePiece tokenizers work' +
+                  ' (this is expected if you\'re not using them).')
+
 
 class ConcatMode(Enum):
     NO_CONCAT = 'NO_CONCAT'

--- a/examples/common/generate_callback.py
+++ b/examples/common/generate_callback.py
@@ -1,0 +1,93 @@
+# Copyright 2022 MosaicML Examples authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Periodically log generations to wandb from a set of prompts."""
+from typing import List
+
+import wandb
+from composer.core import Callback, State
+from composer.loggers import Logger, WandBLogger
+from composer.utils import dist, ensure_tuple
+
+
+class Generate(Callback):
+
+    def __init__(self, prompts: List[str], **kwargs):
+        """Periodically log generations to wandb from a set of prompts.
+
+        In the main view for a run, there will be a table that will show the _last_ logged generations.
+        To compare previous iterations of the generations, you need to
+        1. Click on the run
+        2. Click on "artifacts" in the menu on the left side of the screen
+        3. Click on one of the artifacts called "predictions"
+        4. Click on the "files" tab
+        5. Click on "predictions.table.json"
+        6. On the left hand side, there are different versions of the table produced throughout training. Select one of these.
+        7. Now, when you hover over other versions, there will be a "compare" button, which will allow you to compare the currently
+            selected version to the version you add via compare.
+
+        Args:
+            prompts (List[str]): The list of prompts you would like to produce generations for
+            kwargs: All kwargs well be passed along to the call to generate. This is for things like `do_sample`, `top_p`, etc
+        """
+        self.prompts = prompts
+        self.generate_kwargs = kwargs
+        self.wandb_logger = None
+
+    def init(self, state: State, logger: Logger):
+        if dist.get_global_rank() == 0:
+            for destination in ensure_tuple(logger.destinations):
+                if isinstance(destination, WandBLogger):
+                    self.wandb_logger = destination
+
+    def eval_end(self, state: State, logger: Logger):
+        model = state.model
+        tokenizer = state.model.tokenizer
+        device = state.device
+
+        # stash the original original value of padding_side because generation requires left padding
+        original_padding_side = tokenizer.padding_side
+        tokenizer.padding_side = 'left'
+        if tokenizer.pad_token_id is None:
+            tokenizer.pad_token_id = tokenizer.eos_token_id
+        tokenized_input = tokenizer(self.prompts,
+                                    return_tensors='pt',
+                                    padding=True)
+
+        for k, v in tokenized_input.items():
+            tokenized_input[k] = device.tensor_to_device(v)
+
+        output_token_ids = model.model.generate(
+            input_ids=tokenized_input['input_ids'],
+            attention_mask=tokenized_input['attention_mask'],
+            synced_gpus=True,
+            **self.generate_kwargs,
+        )
+
+        if dist.get_global_rank() == 0:
+            if self.wandb_logger is not None:
+                artifact = wandb.Artifact('generate_samples_' +
+                                          str(wandb.run.id),
+                                          type='predictions')
+
+                rows = []
+                for i in range(len(self.prompts)):
+                    prompt = self.prompts[i]
+                    output_tokens = output_token_ids[i][
+                        tokenized_input['input_ids'].shape[1]:]
+                    output_text = tokenizer.decode(output_tokens,
+                                                   skip_special_tokens=True)
+
+                    rows.append([prompt, output_text])
+
+                text_table = wandb.Table(data=rows,
+                                         columns=['prompt', 'generation'])
+                artifact.add(text_table, 'predictions')
+                wandb.log_artifact(artifact)
+                wandb.log({'generations': text_table},
+                          step=state.timestamp.batch.value)
+
+        tokenizer.padding_side = original_padding_side

--- a/examples/common/text_data.py
+++ b/examples/common/text_data.py
@@ -15,6 +15,14 @@ from omegaconf import OmegaConf as om
 from streaming import StreamingDataset
 from torch.utils.data import DataLoader
 
+try:
+    from examples.llm.src.models.utils import make_llama_work
+    make_llama_work()
+except ImportError:
+    import warnings
+    warnings.warn('Couldn\'t make Llama/Custom SentencePiece tokenizers work' +
+                  ' (this is expected if you\'re not using them).')
+
 
 class StreamingTextDataset(StreamingDataset):
     """Generic text dataset using MosaicML's StreamingDataset.

--- a/examples/llm/requirements.txt
+++ b/examples/llm/requirements.txt
@@ -12,3 +12,4 @@ wandb==0.13.6
 pytest>=7.2.1,<8
 torchmetrics==0.11.3
 xentropy-cuda-lib@git+https://github.com/HazyResearch/flash-attention.git@v0.2.8#subdirectory=csrc/xentropy
+sentencepiece==0.1.97

--- a/examples/llm/src/models/utils/__init__.py
+++ b/examples/llm/src/models/utils/__init__.py
@@ -1,6 +1,8 @@
 # Copyright 2022 MosaicML Examples authors
 # SPDX-License-Identifier: Apache-2.0
 
+from make_llama_work_with_autoclass import make_llama_work
+
 from examples.llm.src.models.utils.adapt_tokenizer import (
     AutoTokenizerForMOD, adapt_tokenizer_for_denoising)
 from examples.llm.src.models.utils.hf_prefixlm_converter import (
@@ -13,5 +15,5 @@ __all__ = [
     'AutoTokenizerForMOD', 'adapt_tokenizer_for_denoising',
     'convert_hf_causal_lm_to_prefix_lm', 'init_empty_weights',
     'add_bidirectional_mask_if_missing', 'generic_param_init_fn_',
-    'MODEL_INIT_REGISTRY'
+    'MODEL_INIT_REGISTRY', 'make_llama_work'
 ]

--- a/examples/llm/src/models/utils/make_llama_work_with_autoclass.py
+++ b/examples/llm/src/models/utils/make_llama_work_with_autoclass.py
@@ -1,0 +1,329 @@
+# Copyright 2022 MosaicML Examples authors
+# SPDX-License-Identifier: Apache-2.0
+
+# coding=utf-8
+# Copyright 2022 EleutherAI and the HuggingFace Inc. team. All rights reserved.
+#
+# This code is based on EleutherAI's GPT-NeoX library and the GPT-NeoX
+# and OPT implementations in this library. It has been modified from its
+# original forms to accommodate minor architectural differences compared
+# to GPT-NeoX and OPT used by the Meta AI team that trained the model.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LLaMA model configuration and tokenizer.
+
+REMOVE THIS CODE when we upgrade to a version of transformers that has the
+LlamaTokenizer code
+"""
+
+import os
+from shutil import copyfile
+from typing import Any, Dict, List, Optional, Tuple
+
+import sentencepiece as spm
+from transformers import AutoTokenizer
+from transformers.configuration_utils import PretrainedConfig
+from transformers.tokenization_utils import AddedToken, PreTrainedTokenizer
+from transformers.utils import logging
+
+
+class LlamaConfig(PretrainedConfig):
+    model_type = 'llama'
+
+    def __init__(
+        self,
+        vocab_size=32000,
+        hidden_size=4096,
+        intermediate_size=11008,
+        num_hidden_layers=32,
+        num_attention_heads=32,
+        hidden_act='silu',
+        max_position_embeddings=2048,
+        initializer_range=0.02,
+        rms_norm_eps=1e-6,
+        use_cache=True,
+        pad_token_id=0,
+        bos_token_id=1,
+        eos_token_id=2,
+        tie_word_embeddings=False,
+        **kwargs,
+    ):
+        self.vocab_size = vocab_size
+        self.max_position_embeddings = max_position_embeddings
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.hidden_act = hidden_act
+        self.initializer_range = initializer_range
+        self.rms_norm_eps = rms_norm_eps
+        self.use_cache = use_cache
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )
+
+
+class mC4SentencePieceConfig(LlamaConfig):
+
+    def __init__(self, *args, **kwargs):
+        super.__init__(
+            *args,
+            vocab_size=65500,
+            pad_token_id=3,
+            tie_word_embeddings=False,
+            **kwargs,
+        )
+
+
+##
+# tokenizer
+##
+
+logger = logging.get_logger(__name__)
+
+VOCAB_FILES_NAMES = {'vocab_file': 'tokenizer.model'}
+
+PRETRAINED_VOCAB_FILES_MAP = {
+    'vocab_file': {
+        'hf-internal-testing/llama-tokenizer':
+            'https://huggingface.co/hf-internal-testing/llama-tokenizer/resolve/main/tokenizer.model',
+    },
+    'tokenizer_file': {
+        'hf-internal-testing/llama-tokenizer':
+            'https://huggingface.co/hf-internal-testing/llama-tokenizer/resolve/main/tokenizer_config.json',
+    },
+}
+PRETRAINED_POSITIONAL_EMBEDDINGS_SIZES = {
+    'hf-internal-testing/llama-tokenizer': 2048,
+}
+
+
+class LlamaTokenizer(PreTrainedTokenizer):
+    """Construct a Llama tokenizer. Based on byte-level Byte-Pair-Encoding.
+
+    Args:
+        vocab_file (`str`):
+            Path to the vocabulary file.
+    """
+
+    vocab_files_names = VOCAB_FILES_NAMES
+    pretrained_vocab_files_map = PRETRAINED_VOCAB_FILES_MAP
+    max_model_input_sizes = PRETRAINED_POSITIONAL_EMBEDDINGS_SIZES
+    model_input_names = ['input_ids', 'attention_mask']
+
+    def __init__(
+        self,
+        vocab_file,
+        unk_token='<unk>',
+        bos_token='<s>',
+        eos_token='</s>',
+        pad_token=None,
+        sp_model_kwargs: Optional[Dict[str, Any]] = None,
+        add_bos_token=True,
+        add_eos_token=False,
+        clean_up_tokenization_spaces=False,
+        **kwargs,
+    ):
+        self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
+        bos_token = AddedToken(bos_token,
+                               lstrip=False, rstrip=False) if isinstance(
+                                   bos_token, str) else bos_token
+        eos_token = AddedToken(eos_token,
+                               lstrip=False, rstrip=False) if isinstance(
+                                   eos_token, str) else eos_token
+        unk_token = AddedToken(unk_token,
+                               lstrip=False, rstrip=False) if isinstance(
+                                   unk_token, str) else unk_token
+        pad_token = AddedToken(pad_token,
+                               lstrip=False, rstrip=False) if isinstance(
+                                   pad_token, str) else pad_token
+        super().__init__(
+            bos_token=bos_token,
+            eos_token=eos_token,
+            unk_token=unk_token,
+            pad_token=pad_token,
+            add_bos_token=add_bos_token,
+            add_eos_token=add_eos_token,
+            sp_model_kwargs=self.sp_model_kwargs,
+            clean_up_tokenization_spaces=clean_up_tokenization_spaces,
+            **kwargs,
+        )
+        self.vocab_file = vocab_file
+        self.add_bos_token = add_bos_token
+        self.add_eos_token = add_eos_token
+        self.sp_model = spm.SentencePieceProcessor(**self.sp_model_kwargs)
+        self.sp_model.Load(vocab_file)
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state['sp_model'] = None
+        return state
+
+    def __setstate__(self, d):
+        self.__dict__ = d
+        self.sp_model = spm.SentencePieceProcessor(**self.sp_model_kwargs)
+        self.sp_model.Load(self.vocab_file)
+
+    @property
+    def vocab_size(self):
+        """Returns vocab size."""
+        return self.sp_model.get_piece_size()
+
+    def get_vocab(self):
+        """Returns vocab as a dict."""
+        vocab = {
+            self.convert_ids_to_tokens(i): i for i in range(self.vocab_size)
+        }
+        vocab.update(self.added_tokens_encoder)
+        return vocab
+
+    def _tokenize(self, text):
+        """Returns a tokenized string."""
+        return self.sp_model.encode(text, out_type=str)
+
+    def _convert_token_to_id(self, token):
+        """Converts a token (str) in an id using the vocab."""
+        return self.sp_model.piece_to_id(token)
+
+    def _convert_id_to_token(self, index):
+        """Converts an index (integer) in a token (str) using the vocab."""
+        token = self.sp_model.IdToPiece(index)
+        return token
+
+    def convert_tokens_to_string(self, tokens):
+        """Converts a sequence of tokens (string) in a single string."""
+        current_sub_tokens = []
+        out_string = ''
+        prev_is_special = False
+        for i, token in enumerate(tokens):
+            # make sure that special tokens are not decoded using sentencepiece model
+            if token in self.all_special_tokens:
+                if not prev_is_special and i != 0:
+                    out_string += ' '
+                out_string += self.sp_model.decode(current_sub_tokens) + token
+                prev_is_special = True
+                current_sub_tokens = []
+            else:
+                current_sub_tokens.append(token)
+                prev_is_special = False
+        out_string += self.sp_model.decode(current_sub_tokens)
+        return out_string
+
+    def save_vocabulary(self,
+                        save_directory,
+                        filename_prefix: Optional[str] = None) -> Tuple[str]:
+        """Save the vocabulary and special tokens file to a directory.
+
+        Args:
+            save_directory (`str`):
+                The directory in which to save the vocabulary.
+
+        Returns:
+            `Tuple(str)`: Paths to the files saved.
+        """
+        if not os.path.isdir(save_directory):
+            logger.error(
+                f'Vocabulary path ({save_directory}) should be a directory')
+            return
+        out_vocab_file = os.path.join(
+            save_directory, (filename_prefix + '-' if filename_prefix else '') +
+            VOCAB_FILES_NAMES['vocab_file'])
+
+        if os.path.abspath(self.vocab_file) != os.path.abspath(
+                out_vocab_file) and os.path.isfile(self.vocab_file):
+            copyfile(self.vocab_file, out_vocab_file)
+        elif not os.path.isfile(self.vocab_file):
+            with open(out_vocab_file, 'wb') as fi:
+                content_spiece_model = self.sp_model.serialized_model_proto()
+                fi.write(content_spiece_model)
+
+        return (out_vocab_file,)
+
+    def build_inputs_with_special_tokens(self, token_ids_0, token_ids_1=None):
+        bos_token_id = [self.bos_token_id] if self.add_bos_token else []
+        eos_token_id = [self.eos_token_id] if self.add_eos_token else []
+
+        output = bos_token_id + token_ids_0 + eos_token_id
+
+        if token_ids_1 is not None:
+            output = output + bos_token_id + token_ids_1 + eos_token_id
+
+        return output
+
+    def get_special_tokens_mask(
+            self,
+            token_ids_0: List[int],
+            token_ids_1: Optional[List[int]] = None,
+            already_has_special_tokens: bool = False) -> List[int]:
+
+        if already_has_special_tokens:
+            return super().get_special_tokens_mask(
+                token_ids_0=token_ids_0,
+                token_ids_1=token_ids_1,
+                already_has_special_tokens=True)
+
+        bos_token_id = [1] if self.add_bos_token else []
+        eos_token_id = [2] if self.add_eos_token else []
+
+        if token_ids_1 is None:
+            return bos_token_id + ([0] * len(token_ids_0)) + eos_token_id
+        return (bos_token_id + ([0] * len(token_ids_0)) + eos_token_id +
+                bos_token_id + ([0] * len(token_ids_1)) + eos_token_id)
+
+    def create_token_type_ids_from_sequences(
+            self,
+            token_ids_0: List[int],
+            token_ids_1: Optional[List[int]] = None) -> List[int]:
+        """Creates a mask from the two sequences.
+
+        An ALBERT sequence pair mask has the following format:
+
+        ```
+        0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1
+        | first sequence    | second sequence |
+        ```
+
+        if token_ids_1 is None, only returns the first portion of the mask (0s).
+
+        Args:
+            token_ids_0 (`List[int]`):
+                List of ids.
+            token_ids_1 (`List[int]`, *optional*):
+                Optional second list of IDs for sequence pairs.
+
+        Returns:
+            `List[int]`: List of [token type IDs](../glossary#token-type-ids) according to the given sequence(s).
+        """
+        sep = [self.sep_token_id]
+        cls = [self.cls_token_id]
+
+        if token_ids_1 is None:
+            return len(cls + token_ids_0 + sep) * [0]
+        return len(cls + token_ids_0 + sep) * [0] + len(token_ids_1 + sep) * [1]
+
+
+# as long as this line is invoked, you can call AutoTokenizer.from_pretrained on a
+# model that uses LlamaTokenizer
+AutoTokenizer.register(mC4SentencePieceConfig,
+                       slow_tokenizer_class=LlamaTokenizer)
+
+
+def make_llama_work():
+    # it was actually just importing this class that makes it work
+    # this is so pyrite is happy
+    pass


### PR DESCRIPTION
This adds some HF code that we can delete once we upgrade to a currently unreleased version that supports a certain type of sentencepiece tokenizer.

It also adds sentencepiece as an llm dependency, which is coming soon anyway.

Finally, it imports this code into common/convert_dataset.py and common/text_data.py to make it so AutoTokenizer.from_pretrained can be called with our new custom tokenizers and the Llama tokenizer