### PR TITLE
make LlamaTokenizer work for tokenizer bakeoff

### DIFF
--- a/examples/common/convert_dataset.py
+++ b/examples/common/convert_dataset.py
@@ -17,6 +17,14 @@ from torch.utils.data import DataLoader, IterableDataset, get_worker_info
 from tqdm import tqdm
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
+try:
+    from examples.llm.src.models.utils import make_llama_work
+    make_llama_work()
+except ImportError:
+    import warnings
+    warnings.warn('Couldn\'t make Llama/Custom SentencePiece tokenizers work' +
+                  ' (this is expected if you\'re not using them).')
+
 
 class ConcatMode(Enum):
     NO_CONCAT = 'NO_CONCAT'

--- a/examples/common/text_data.py
+++ b/examples/common/text_data.py
@@ -15,6 +15,14 @@ from omegaconf import OmegaConf as om
 from streaming import StreamingDataset
 from torch.utils.data import DataLoader
 
+try:
+    from examples.llm.src.models.utils import make_llama_work
+    make_llama_work()
+except ImportError:
+    import warnings
+    warnings.warn('Couldn\'t make Llama/Custom SentencePiece tokenizers work' +
+                  ' (this is expected if you\'re not using them).')
+
 
 class StreamingTextDataset(StreamingDataset):
     """Generic text dataset using MosaicML's StreamingDataset.

--- a/examples/llm/requirements.txt
+++ b/examples/llm/requirements.txt
@@ -12,3 +12,4 @@ wandb==0.13.6
 pytest>=7.2.1,<8
 torchmetrics==0.11.3
 xentropy-cuda-lib@git+https://github.com/HazyResearch/flash-attention.git@v0.2.8#subdirectory=csrc/xentropy
+sentencepiece==0.1.97

--- a/examples/llm/src/models/utils/__init__.py
+++ b/examples/llm/src/models/utils/__init__.py
@@ -1,12 +1,12 @@
 # Copyright 2022 MosaicML Examples authors
 # SPDX-License-Identifier: Apache-2.0
 
-from make_llama_work_with_autoclass import make_llama_work
-
 from examples.llm.src.models.utils.adapt_tokenizer import (
     AutoTokenizerForMOD, adapt_tokenizer_for_denoising)
 from examples.llm.src.models.utils.hf_prefixlm_converter import (
     add_bidirectional_mask_if_missing, convert_hf_causal_lm_to_prefix_lm)
+from examples.llm.src.models.utils.make_llama_work_with_autoclass import \
+    make_llama_work
 from examples.llm.src.models.utils.meta_init_context import init_empty_weights
 from examples.llm.src.models.utils.param_init_fns import (  # type: ignore
     MODEL_INIT_REGISTRY, generic_param_init_fn_)

--- a/examples/llm/src/models/utils/__init__.py
+++ b/examples/llm/src/models/utils/__init__.py
@@ -1,6 +1,8 @@
 # Copyright 2022 MosaicML Examples authors
 # SPDX-License-Identifier: Apache-2.0
 
+from make_llama_work_with_autoclass import make_llama_work
+
 from examples.llm.src.models.utils.adapt_tokenizer import (
     AutoTokenizerForMOD, adapt_tokenizer_for_denoising)
 from examples.llm.src.models.utils.hf_prefixlm_converter import (
@@ -13,5 +15,5 @@ __all__ = [
     'AutoTokenizerForMOD', 'adapt_tokenizer_for_denoising',
     'convert_hf_causal_lm_to_prefix_lm', 'init_empty_weights',
     'add_bidirectional_mask_if_missing', 'generic_param_init_fn_',
-    'MODEL_INIT_REGISTRY'
+    'MODEL_INIT_REGISTRY', 'make_llama_work'
 ]

--- a/examples/llm/src/models/utils/make_llama_work_with_autoclass.py
+++ b/examples/llm/src/models/utils/make_llama_work_with_autoclass.py
@@ -81,11 +81,11 @@ class LlamaConfig(PretrainedConfig):
 class C4SentencePieceConfig(LlamaConfig):
 
     def __init__(self, *args, **kwargs):
+        kwargs['vocab_size'] = 65500
+        kwargs['pad_token_id'] = 3
+        kwargs['tie_word_embeddings'] = False
         super.__init__(
             *args,
-            vocab_size=65500,
-            pad_token_id=3,
-            tie_word_embeddings=False,
             **kwargs,
         )
 
@@ -224,9 +224,10 @@ class LlamaTokenizer(PreTrainedTokenizer):
         out_string += self.sp_model.decode(current_sub_tokens)
         return out_string
 
-    def save_vocabulary(self,
-                        save_directory,
-                        filename_prefix: Optional[str] = None) -> Tuple[str]:
+    def save_vocabulary(
+            self,
+            save_directory,
+            filename_prefix: Optional[str] = None) -> Optional[Tuple[str]]:
         """Save the vocabulary and special tokens file to a directory.
 
         Args:

--- a/examples/llm/src/models/utils/make_llama_work_with_autoclass.py
+++ b/examples/llm/src/models/utils/make_llama_work_with_autoclass.py
@@ -83,7 +83,6 @@ class C4SentencePieceConfig(LlamaConfig):
     def __init__(self, *args, **kwargs):
         kwargs['vocab_size'] = 65500
         kwargs['pad_token_id'] = 3
-        kwargs['tie_word_embeddings'] = False
         super.__init__(
             *args,
             **kwargs,

--- a/examples/llm/src/models/utils/make_llama_work_with_autoclass.py
+++ b/examples/llm/src/models/utils/make_llama_work_with_autoclass.py
@@ -78,17 +78,6 @@ class LlamaConfig(PretrainedConfig):
         )
 
 
-class C4SentencePieceConfig(LlamaConfig):
-
-    def __init__(self, *args, **kwargs):
-        kwargs['vocab_size'] = 65500
-        kwargs['pad_token_id'] = 3
-        super.__init__(
-            *args,
-            **kwargs,
-        )
-
-
 ##
 # tokenizer
 ##
@@ -319,8 +308,7 @@ class LlamaTokenizer(PreTrainedTokenizer):
 
 # as long as this line is invoked, you can call AutoTokenizer.from_pretrained on a
 # model that uses LlamaTokenizer
-AutoTokenizer.register(C4SentencePieceConfig,
-                       slow_tokenizer_class=LlamaTokenizer)
+AutoTokenizer.register(LlamaConfig, slow_tokenizer_class=LlamaTokenizer)
 
 
 def make_llama_work():

--- a/examples/llm/src/models/utils/make_llama_work_with_autoclass.py
+++ b/examples/llm/src/models/utils/make_llama_work_with_autoclass.py
@@ -1,0 +1,329 @@
+# Copyright 2022 MosaicML Examples authors
+# SPDX-License-Identifier: Apache-2.0
+
+# coding=utf-8
+# Copyright 2022 EleutherAI and the HuggingFace Inc. team. All rights reserved.
+#
+# This code is based on EleutherAI's GPT-NeoX library and the GPT-NeoX
+# and OPT implementations in this library. It has been modified from its
+# original forms to accommodate minor architectural differences compared
+# to GPT-NeoX and OPT used by the Meta AI team that trained the model.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LLaMA model configuration and tokenizer.
+
+REMOVE THIS CODE when we upgrade to a version of transformers that has the
+LlamaTokenizer code
+"""
+
+import os
+from shutil import copyfile
+from typing import Any, Dict, List, Optional, Tuple
+
+import sentencepiece as spm
+from transformers import AutoTokenizer
+from transformers.configuration_utils import PretrainedConfig
+from transformers.tokenization_utils import AddedToken, PreTrainedTokenizer
+from transformers.utils import logging
+
+
+class LlamaConfig(PretrainedConfig):
+    model_type = 'llama'
+
+    def __init__(
+        self,
+        vocab_size=32000,
+        hidden_size=4096,
+        intermediate_size=11008,
+        num_hidden_layers=32,
+        num_attention_heads=32,
+        hidden_act='silu',
+        max_position_embeddings=2048,
+        initializer_range=0.02,
+        rms_norm_eps=1e-6,
+        use_cache=True,
+        pad_token_id=0,
+        bos_token_id=1,
+        eos_token_id=2,
+        tie_word_embeddings=False,
+        **kwargs,
+    ):
+        self.vocab_size = vocab_size
+        self.max_position_embeddings = max_position_embeddings
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.hidden_act = hidden_act
+        self.initializer_range = initializer_range
+        self.rms_norm_eps = rms_norm_eps
+        self.use_cache = use_cache
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )
+
+
+class mC4SentencePieceConfig(LlamaConfig):
+
+    def __init__(self, *args, **kwargs):
+        super.__init__(
+            *args,
+            vocab_size=65500,
+            pad_token_id=3,
+            tie_word_embeddings=False,
+            **kwargs,
+        )
+
+
+##
+# tokenizer
+##
+
+logger = logging.get_logger(__name__)
+
+VOCAB_FILES_NAMES = {'vocab_file': 'tokenizer.model'}
+
+PRETRAINED_VOCAB_FILES_MAP = {
+    'vocab_file': {
+        'hf-internal-testing/llama-tokenizer':
+            'https://huggingface.co/hf-internal-testing/llama-tokenizer/resolve/main/tokenizer.model',
+    },
+    'tokenizer_file': {
+        'hf-internal-testing/llama-tokenizer':
+            'https://huggingface.co/hf-internal-testing/llama-tokenizer/resolve/main/tokenizer_config.json',
+    },
+}
+PRETRAINED_POSITIONAL_EMBEDDINGS_SIZES = {
+    'hf-internal-testing/llama-tokenizer': 2048,
+}
+
+
+class LlamaTokenizer(PreTrainedTokenizer):
+    """Construct a Llama tokenizer. Based on byte-level Byte-Pair-Encoding.
+
+    Args:
+        vocab_file (`str`):
+            Path to the vocabulary file.
+    """
+
+    vocab_files_names = VOCAB_FILES_NAMES
+    pretrained_vocab_files_map = PRETRAINED_VOCAB_FILES_MAP
+    max_model_input_sizes = PRETRAINED_POSITIONAL_EMBEDDINGS_SIZES
+    model_input_names = ['input_ids', 'attention_mask']
+
+    def __init__(
+        self,
+        vocab_file,
+        unk_token='<unk>',
+        bos_token='<s>',
+        eos_token='</s>',
+        pad_token=None,
+        sp_model_kwargs: Optional[Dict[str, Any]] = None,
+        add_bos_token=True,
+        add_eos_token=False,
+        clean_up_tokenization_spaces=False,
+        **kwargs,
+    ):
+        self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
+        bos_token = AddedToken(bos_token,
+                               lstrip=False, rstrip=False) if isinstance(
+                                   bos_token, str) else bos_token
+        eos_token = AddedToken(eos_token,
+                               lstrip=False, rstrip=False) if isinstance(
+                                   eos_token, str) else eos_token
+        unk_token = AddedToken(unk_token,
+                               lstrip=False, rstrip=False) if isinstance(
+                                   unk_token, str) else unk_token
+        pad_token = AddedToken(pad_token,
+                               lstrip=False, rstrip=False) if isinstance(
+                                   pad_token, str) else pad_token
+        super().__init__(
+            bos_token=bos_token,
+            eos_token=eos_token,
+            unk_token=unk_token,
+            pad_token=pad_token,
+            add_bos_token=add_bos_token,
+            add_eos_token=add_eos_token,
+            sp_model_kwargs=self.sp_model_kwargs,
+            clean_up_tokenization_spaces=clean_up_tokenization_spaces,
+            **kwargs,
+        )
+        self.vocab_file = vocab_file
+        self.add_bos_token = add_bos_token
+        self.add_eos_token = add_eos_token
+        self.sp_model = spm.SentencePieceProcessor(**self.sp_model_kwargs)
+        self.sp_model.Load(vocab_file)
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state['sp_model'] = None
+        return state
+
+    def __setstate__(self, d):
+        self.__dict__ = d
+        self.sp_model = spm.SentencePieceProcessor(**self.sp_model_kwargs)
+        self.sp_model.Load(self.vocab_file)
+
+    @property
+    def vocab_size(self):
+        """Returns vocab size."""
+        return self.sp_model.get_piece_size()
+
+    def get_vocab(self):
+        """Returns vocab as a dict."""
+        vocab = {
+            self.convert_ids_to_tokens(i): i for i in range(self.vocab_size)
+        }
+        vocab.update(self.added_tokens_encoder)
+        return vocab
+
+    def _tokenize(self, text):
+        """Returns a tokenized string."""
+        return self.sp_model.encode(text, out_type=str)
+
+    def _convert_token_to_id(self, token):
+        """Converts a token (str) in an id using the vocab."""
+        return self.sp_model.piece_to_id(token)
+
+    def _convert_id_to_token(self, index):
+        """Converts an index (integer) in a token (str) using the vocab."""
+        token = self.sp_model.IdToPiece(index)
+        return token
+
+    def convert_tokens_to_string(self, tokens):
+        """Converts a sequence of tokens (string) in a single string."""
+        current_sub_tokens = []
+        out_string = ''
+        prev_is_special = False
+        for i, token in enumerate(tokens):
+            # make sure that special tokens are not decoded using sentencepiece model
+            if token in self.all_special_tokens:
+                if not prev_is_special and i != 0:
+                    out_string += ' '
+                out_string += self.sp_model.decode(current_sub_tokens) + token
+                prev_is_special = True
+                current_sub_tokens = []
+            else:
+                current_sub_tokens.append(token)
+                prev_is_special = False
+        out_string += self.sp_model.decode(current_sub_tokens)
+        return out_string
+
+    def save_vocabulary(self,
+                        save_directory,
+                        filename_prefix: Optional[str] = None) -> Tuple[str]:
+        """Save the vocabulary and special tokens file to a directory.
+
+        Args:
+            save_directory (`str`):
+                The directory in which to save the vocabulary.
+
+        Returns:
+            `Tuple(str)`: Paths to the files saved.
+        """
+        if not os.path.isdir(save_directory):
+            logger.error(
+                f'Vocabulary path ({save_directory}) should be a directory')
+            return
+        out_vocab_file = os.path.join(
+            save_directory, (filename_prefix + '-' if filename_prefix else '') +
+            VOCAB_FILES_NAMES['vocab_file'])
+
+        if os.path.abspath(self.vocab_file) != os.path.abspath(
+                out_vocab_file) and os.path.isfile(self.vocab_file):
+            copyfile(self.vocab_file, out_vocab_file)
+        elif not os.path.isfile(self.vocab_file):
+            with open(out_vocab_file, 'wb') as fi:
+                content_spiece_model = self.sp_model.serialized_model_proto()
+                fi.write(content_spiece_model)
+
+        return (out_vocab_file,)
+
+    def build_inputs_with_special_tokens(self, token_ids_0, token_ids_1=None):
+        bos_token_id = [self.bos_token_id] if self.add_bos_token else []
+        eos_token_id = [self.eos_token_id] if self.add_eos_token else []
+
+        output = bos_token_id + token_ids_0 + eos_token_id
+
+        if token_ids_1 is not None:
+            output = output + bos_token_id + token_ids_1 + eos_token_id
+
+        return output
+
+    def get_special_tokens_mask(
+            self,
+            token_ids_0: List[int],
+            token_ids_1: Optional[List[int]] = None,
+            already_has_special_tokens: bool = False) -> List[int]:
+
+        if already_has_special_tokens:
+            return super().get_special_tokens_mask(
+                token_ids_0=token_ids_0,
+                token_ids_1=token_ids_1,
+                already_has_special_tokens=True)
+
+        bos_token_id = [1] if self.add_bos_token else []
+        eos_token_id = [2] if self.add_eos_token else []
+
+        if token_ids_1 is None:
+            return bos_token_id + ([0] * len(token_ids_0)) + eos_token_id
+        return (bos_token_id + ([0] * len(token_ids_0)) + eos_token_id +
+                bos_token_id + ([0] * len(token_ids_1)) + eos_token_id)
+
+    def create_token_type_ids_from_sequences(
+            self,
+            token_ids_0: List[int],
+            token_ids_1: Optional[List[int]] = None) -> List[int]:
+        """Creates a mask from the two sequences.
+
+        An ALBERT sequence pair mask has the following format:
+
+        ```
+        0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1
+        | first sequence    | second sequence |
+        ```
+
+        if token_ids_1 is None, only returns the first portion of the mask (0s).
+
+        Args:
+            token_ids_0 (`List[int]`):
+                List of ids.
+            token_ids_1 (`List[int]`, *optional*):
+                Optional second list of IDs for sequence pairs.
+
+        Returns:
+            `List[int]`: List of [token type IDs](../glossary#token-type-ids) according to the given sequence(s).
+        """
+        sep = [self.sep_token_id]
+        cls = [self.cls_token_id]
+
+        if token_ids_1 is None:
+            return len(cls + token_ids_0 + sep) * [0]
+        return len(cls + token_ids_0 + sep) * [0] + len(token_ids_1 + sep) * [1]
+
+
+# as long as this line is invoked, you can call AutoTokenizer.from_pretrained on a
+# model that uses LlamaTokenizer
+AutoTokenizer.register(mC4SentencePieceConfig,
+                       slow_tokenizer_class=LlamaTokenizer)
+
+
+def make_llama_work():
+    # it was actually just importing this class that makes it work
+    # this is so pyrite is happy
+    pass

--- a/examples/llm/src/models/utils/make_llama_work_with_autoclass.py
+++ b/examples/llm/src/models/utils/make_llama_work_with_autoclass.py
@@ -78,7 +78,7 @@ class LlamaConfig(PretrainedConfig):
         )
 
 
-class mC4SentencePieceConfig(LlamaConfig):
+class C4SentencePieceConfig(LlamaConfig):
 
     def __init__(self, *args, **kwargs):
         super.__init__(
@@ -319,7 +319,7 @@ class LlamaTokenizer(PreTrainedTokenizer):
 
 # as long as this line is invoked, you can call AutoTokenizer.from_pretrained on a
 # model that uses LlamaTokenizer
-AutoTokenizer.register(mC4SentencePieceConfig,
+AutoTokenizer.register(C4SentencePieceConfig,
                        slow_tokenizer_class=LlamaTokenizer)
 
 


### PR DESCRIPTION
This adds some HF code that we can delete once we upgrade to a currently unreleased version that supports a certain type of sentencepiece tokenizer.

It also adds sentencepiece as an llm dependency, which is coming soon anyway.

Finally, it imports this code into common/convert_dataset.py and common/text_data.py to make it so AutoTokenizer.from_pretrained can be called with our new custom tokenizers and the Llama tokenizer