### PR TITLE
Monolithic Checkpoint Callback

### DIFF
--- a/examples/common/builders.py
+++ b/examples/common/builders.py
@@ -21,6 +21,7 @@ from examples.common.generate_callback import Generate
 from examples.common.optim import (DecoupledAdaLRLion, DecoupledClipLion,
                                    DecoupledLionW)
 from examples.common.resumption_callbacks import GlobalLRScaling, LayerFreezing
+from examples.common.monolithic_chkpt_callback import MonolithicCheckpointSaver
 from examples.common.text_data import build_text_dataloader
 
 
@@ -49,6 +50,8 @@ def build_callback(name, kwargs):
         return GlobalLRScaling(**kwargs)
     elif name == 'layer_freezing':
         return LayerFreezing(**kwargs)
+    elif name == 'mono_chkpt_saver':
+        return MonolithicCheckpointSaver(**kwargs)
     else:
         raise ValueError(f'Not sure how to build callback: {name}')
 

--- a/examples/common/monolithic_chkpt_callback.py
+++ b/examples/common/monolithic_chkpt_callback.py
@@ -57,7 +57,7 @@ class MonolithicCheckpointSaver(Callback):
                 if dirname:
                     os.makedirs(dirname, exist_ok=True)
                 with fsdp_state_dict_type_context(state.model, state_dict_type='full'):
-                    state_dict = {'state': {'model': state.model.state_dict()}}
+                    state_dict = {'state': {'model': state.model.state_dict(), 'rng': reproducibility.get_rng_state()}}
                     if dist.get_global_rank() == 0:
                         torch.save(state_dict, save_path)
 

--- a/examples/common/monolithic_chkpt_callback.py
+++ b/examples/common/monolithic_chkpt_callback.py
@@ -1,0 +1,63 @@
+from composer.core import Callback, State
+from composer.loggers import Logger
+from composer.utils import parse_uri, format_name_with_dist_and_time, reproducibility
+from composer.loggers.remote_uploader_downloader import RemoteUploaderDownloader
+import tempfile
+from pathlib import Path
+from composer.core.state import fsdp_state_dict_type_context
+import torch
+import os
+
+
+class MonolithicCheckpointSaver(Callback):
+    """This callback can be applied upon resuming a model checkpoint.
+
+    Args:
+        save_folder (str): Folder to save checkpoints to (can be a URI)
+        filename (str): Filename to save checkpoints to.
+        batch_interval (int): Number of batches between checkpoints.
+    """
+    def __init__(self, save_folder: str, batch_interval: int, filename: str='ep{epoch}-ba{batch}-rank{rank}.pt'):
+        self.backend, self.bucket_name, self.save_dir_format_str = parse_uri(save_folder)
+        self.filename_format_str = filename
+        self.batch_interval = batch_interval
+        self.upload_to_object_store = (self.backend != '')
+
+    def init(self, state: State, logger: Logger):
+        if self.upload_to_object_store:
+            remote_ud_exists = False
+            remote_uploader_downloaders = [ld for ld in logger.destinations if isinstance(ld, RemoteUploaderDownloader)]
+            for remote_ud in remote_uploader_downloaders:
+                if remote_ud.remote_backend_name == self.backend and remote_ud.remote_bucket_name == self.bucket_name:
+                    remote_ud_exists = True
+                    break
+            if not remote_ud_exists:
+                new_remote_ud = RemoteUploaderDownloader(bucket_uri=f'{self.backend}://{self.bucket_name}')
+                new_remote_ud.init(state, logger)
+                updated_logger_destinations = [*logger.destinations, new_remote_ud]
+                logger.destinations = tuple(updated_logger_destinations)
+                state.callbacks.append(new_remote_ud)
+
+    def batch_checkpoint(self, state: State, logger: Logger):
+        if state.timestamp.batch.value % self.batch_interval == 0:
+            filename = format_name_with_dist_and_time(self.filename_format_str, state.run_name, state.timestamp)
+            save_dir = format_name_with_dist_and_time(self.save_dir_format_str, state.run_name, state.timestamp)
+            if self.upload_to_object_store:
+                with tempfile.TemporaryDirectory() as tempdir:
+                    temp_save_path = str(Path(tempdir) / Path(filename))
+                    with fsdp_state_dict_type_context(state.model, state_dict_type='full'):
+                        state_dict = {'state': {'model': state.model.state_dict()}, 'rng': reproducibility.get_rng_state()}
+                        torch.save(state_dict, temp_save_path)
+                    remote_file_name = str(Path(save_dir) / Path(filename))
+                    logger.upload_file(remote_file_name=remote_file_name, file_path=temp_save_path)
+            else:
+                save_path = str(Path(save_dir) / Path(filename))
+                dirname = os.path.dirname(save_path)
+                if dirname:
+                    os.makedirs(dirname, exist_ok=True)
+                with fsdp_state_dict_type_context(state.model, state_dict_type='full'):
+                    state_dict = {'state': {'model': state.model.state_dict()}}
+                    torch.save(state_dict, save_path)
+
+
+

--- a/examples/common/monolithic_chkpt_callback.py
+++ b/examples/common/monolithic_chkpt_callback.py
@@ -31,8 +31,6 @@ class MonolithicCheckpointSaver(Callback):
         else:
             self.remote_ud = None
         
-
-
     def init(self, state: State, logger: Logger):
         if self.upload_to_object_store:
             self.remote_ud.init(state, logger)

--- a/examples/common/monolithic_chkpt_callback.py
+++ b/examples/common/monolithic_chkpt_callback.py
@@ -45,6 +45,9 @@ class MonolithicCheckpointSaver(Callback):
             if self.upload_to_object_store:
                 with tempfile.TemporaryDirectory() as tempdir:
                     temp_save_path = str(Path(tempdir) / Path(filename))
+                    dirname = os.path.dirname(temp_save_path)
+                    if dirname:
+                        os.makedirs(dirname, exist_ok=True)
                     with fsdp_state_dict_type_context(state.model, state_dict_type='full'):
                         state_dict = {'state': {'model': state.model.state_dict()}, 'rng': reproducibility.get_rng_state()}
                         torch.save(state_dict, temp_save_path)

--- a/examples/common/monolithic_chkpt_callback.py
+++ b/examples/common/monolithic_chkpt_callback.py
@@ -50,7 +50,7 @@ class MonolithicCheckpointSaver(Callback):
                         torch.save(state_dict, temp_save_path)
                     remote_file_name = str(Path(save_dir) / Path(filename))
                     if dist.get_global_rank() == 0:
-                        self.remote_ud.upload_file(remote_file_name=remote_file_name, file_path=temp_save_path, overwrite=self.overwrite)
+                        self.remote_ud.upload_file(state=state, remote_file_name=remote_file_name, file_path=temp_save_path, overwrite=self.overwrite)
             else:
                 save_path = str(Path(save_dir) / Path(filename))
                 dirname = os.path.dirname(save_path)

--- a/examples/common/monolithic_chkpt_callback.py
+++ b/examples/common/monolithic_chkpt_callback.py
@@ -18,7 +18,7 @@ class MonolithicCheckpointSaver(Callback):
         filename (str): Filename to save checkpoints to.
         batch_interval (int): Number of batches between checkpoints.
     """
-    def __init__(self, save_folder: str, batch_interval: int, filename: str='ep{epoch}-ba{batch}-rank{rank}.pt', overwrite: bool = False):
+    def __init__(self, save_folder: str, batch_interval: int, filename: str='ep{epoch}-ba{batch}.pt', overwrite: bool = False):
         self.backend, self.bucket_name, self.save_dir_format_str = parse_uri(save_folder)
         self.filename_format_str = filename
         self.batch_interval = batch_interval

--- a/examples/common/monolithic_chkpt_callback.py
+++ b/examples/common/monolithic_chkpt_callback.py
@@ -58,6 +58,3 @@ class MonolithicCheckpointSaver(Callback):
                 if self.upload_to_object_store and dist.get_global_rank() == 0:
                     remote_file_name = str(Path(save_dir) / Path(filename))
                     self.remote_ud.upload_file(state=state, remote_file_name=remote_file_name, file_path=save_path, overwrite=self.overwrite)
-
-
-

--- a/examples/common/monolithic_chkpt_callback.py
+++ b/examples/common/monolithic_chkpt_callback.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from composer.core.state import fsdp_state_dict_type_context
 import torch
 import os
+from composer.utils import dist
 
 
 class MonolithicCheckpointSaver(Callback):
@@ -39,7 +40,7 @@ class MonolithicCheckpointSaver(Callback):
                 state.callbacks.append(new_remote_ud)
 
     def batch_checkpoint(self, state: State, logger: Logger):
-        if state.timestamp.batch.value % self.batch_interval == 0:
+        if state.timestamp.batch.value % self.batch_interval == 0 and dist.get_global_rank() == 0:
             filename = format_name_with_dist_and_time(self.filename_format_str, state.run_name, state.timestamp)
             save_dir = format_name_with_dist_and_time(self.save_dir_format_str, state.run_name, state.timestamp)
             if self.upload_to_object_store:

--- a/examples/common/monolithic_chkpt_callback.py
+++ b/examples/common/monolithic_chkpt_callback.py
@@ -8,6 +8,7 @@ from composer.core.state import fsdp_state_dict_type_context
 import torch
 import os
 from composer.utils import dist
+import contextlib
 
 
 class MonolithicCheckpointSaver(Callback):
@@ -18,12 +19,13 @@ class MonolithicCheckpointSaver(Callback):
         filename (str): Filename to save checkpoints to.
         batch_interval (int): Number of batches between checkpoints.
     """
-    def __init__(self, save_folder: str, batch_interval: int, filename: str='ep{epoch}-ba{batch}.pt', overwrite: bool = False):
+    def __init__(self, save_folder: str, batch_interval: int, filename: str='ep{epoch}-ba{batch}.pt', overwrite: bool = False, keep_optimizers: bool = False):
         self.backend, self.bucket_name, self.save_dir_format_str = parse_uri(save_folder)
         self.filename_format_str = filename
         self.batch_interval = batch_interval
         self.upload_to_object_store = (self.backend != '')
         self.overwrite = overwrite
+        self.keep_optimizers = keep_optimizers
         if self.upload_to_object_store:
             self.remote_ud = RemoteUploaderDownloader(bucket_uri=f'{self.backend}://{self.bucket_name}')
         else:
@@ -42,27 +44,22 @@ class MonolithicCheckpointSaver(Callback):
         if state.timestamp.batch.value % self.batch_interval == 0:
             filename = format_name_with_dist_and_time(self.filename_format_str, state.run_name, state.timestamp)
             save_dir = format_name_with_dist_and_time(self.save_dir_format_str, state.run_name, state.timestamp)
-            if self.upload_to_object_store:
-                with tempfile.TemporaryDirectory() as tempdir:
-                    temp_save_path = str(Path(tempdir) / Path(filename))
-                    dirname = os.path.dirname(temp_save_path)
-                    if dirname:
-                        os.makedirs(dirname, exist_ok=True)
-                    with fsdp_state_dict_type_context(state.model, state_dict_type='full'):
-                        state_dict = {'state': {'model': state.model.state_dict()}, 'rng': reproducibility.get_rng_state()}
-                        torch.save(state_dict, temp_save_path)
-                    remote_file_name = str(Path(save_dir) / Path(filename))
-                    if dist.get_global_rank() == 0:
-                        self.remote_ud.upload_file(state=state, remote_file_name=remote_file_name, file_path=temp_save_path, overwrite=self.overwrite)
-            else:
-                save_path = str(Path(save_dir) / Path(filename))
+            dir_context_mgr = tempfile.TemporaryDirectory() if self.upload_to_object_store else contextlib.nullcontext(enter_result=save_dir)
+            with dir_context_mgr as temp_save_dir:
+                save_path = str(Path(temp_save_dir) / Path(filename))
                 dirname = os.path.dirname(save_path)
                 if dirname:
                     os.makedirs(dirname, exist_ok=True)
+                state_dict = {'state': state.state_dict(), 'rng': reproducibility.get_rng_state()}
+                if not self.keep_optimizers:
+                    state_dict['state'].pop('optimizers')
                 with fsdp_state_dict_type_context(state.model, state_dict_type='full'):
-                    state_dict = {'state': {'model': state.model.state_dict(), 'rng': reproducibility.get_rng_state()}}
+                    state_dict['state']['model'] = state.model.state_dict()
                     if dist.get_global_rank() == 0:
                         torch.save(state_dict, save_path)
+                if self.upload_to_object_store and dist.get_global_rank() == 0:
+                    remote_file_name = str(Path(save_dir) / Path(filename))
+                    self.remote_ud.upload_file(state=state, remote_file_name=remote_file_name, file_path=save_path, overwrite=self.overwrite)
 
 
 


### PR DESCRIPTION
Callback to on the side save monolithic checkpoints.
Manually tested
Usage:

``` 
callbacks:
    mono_ckpt_saver:
      save_folder: s3://mosaicml-internal-checkpoints-test/evan-test/checkpoints/ex-mono-test5/mono-{run_name}
      filename: ba{batch}/monlith.pt
      batch_interval: 2
```