### PR TITLE
Update README, add low precision option for `convert_composer_to_hf.py`

### DIFF
--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -16,9 +16,9 @@ We even packed in a few tricks (e.g. [FlashAttention](https://github.com/HazyRes
 
 You'll find in this folder:
 * `src/models/mosaic_gpt/` - a simple PyTorch GPT model, wrapped in `ComposerModel`, that can scale up to 70B+ parameters
-* `main.py` - a training script that builds a [Composer](https://github.com/mosaicml/composer) Trainer and calls `trainer.fit()`.
+* `main.py` - a training script that builds a [Composer](https://github.com/mosaicml/composer) `Trainer` and calls `trainer.fit()`.
 * `yamls/` - configs for training compute-optimal LLMs from 125M up to 70B parameters.
-* `throughput/` - data on the training throughput of our models on different cluster configurations.
+* `throughput/` - data on the training throughput of MosaicGPT on different cluster configurations.
 * `inference/` - TBD
 * `mcloud/` - examples of how to use [MosaicML platform](https://www.mosaicml.com/platform) to seamlessly launch training, eval, and inference jobs :)
 
@@ -196,7 +196,7 @@ by using [Composer's logging integrations](https://docs.mosaicml.com/en/stable/t
 
 # How many GPUs do I need to train a LLM?
 This is a complicated question in general, but if we assume that you are using FSDP with `FULL_SHARD`,
-activation checkpointing, and DecoupledAdamW, then a good rule of thumb is:
+activation checkpointing, and `DecoupledAdamW`, then a good rule of thumb is:
 
 > Your total cluster memory in GB should be larger than  16 * N (# billions of params).
 

--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -19,14 +19,14 @@ You'll find in this folder:
 * `main.py` - a training script that builds a [Composer](https://github.com/mosaicml/composer) `Trainer` and calls `trainer.fit()`.
 * `yamls/` - configs for training compute-optimal LLMs from 125M up to 70B parameters.
 * `throughput/` - data on the training throughput of MosaicGPT on different cluster configurations.
-* `inference/` - TBD
+* `inference/` - scripts to convert models to HuggingFace or ONNX format, and view generations.
 * `mcloud/` - examples of how to use [MosaicML platform](https://www.mosaicml.com/platform) to seamlessly launch training, eval, and inference jobs :)
 
 
 In the [common](../common) folder, you will also find:
-* `common/builders.py`-
+* `common/builders.py`- A collection of convenient string-to-object mappings used to create objects that get passed to `Trainer`.
 * `common/text_data.py`- a [MosaicML streaming dataset](https://streaming.docs.mosaicml.com/en/stable/) that can be used with a vanilla PyTorch dataloader.
-* `common/convert_dataset.py`- an example of converting generic text data into StreamingDataset `.mds` shard files.
+* `common/convert_dataset.py`- an example of converting generic text data into `StreamingDataset` `.mds` shard files.
 
 At all model scales, we are training the exact same [vanilla PyTorch GPT model](./src/mosaic_gpt.py#L106), with no special parallelism strategies.
 Composer + FSDP does all the heavy lifting to make sure we can scale up without running out of memory and while maintaining high performance.

--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -7,7 +7,7 @@
 
 # Mosaic Large Language Models
 
-This folder contains starter code for training LLMs with Composer + FSDP (in beta, use `mosaicml>=0.12.0`).
+This folder contains starter code for training LLMs with Composer + FSDP.
 
 Our goal was to build the simplest, most flexible, and still performant stack for training LLMs ([see our blog post](https://www.mosaicml.com/blog/gpt-3-quality-for-500k)).
 To emphasize that flexibility, we designed this folder as a simple but feature-complete example of GPT pre-training
@@ -15,15 +15,18 @@ that you should feel free to download, fork, and customize for your application.
 We even packed in a few tricks (e.g. [FlashAttention](https://github.com/HazyResearch/flash-attention)) to make training efficient, and there will be more to come!
 
 You'll find in this folder:
-* `src/mosaic_gpt.py` - a simple PyTorch GPT model, wrapped in `ComposerModel`, that can scale up to 70B parameters
-* `main.py` - a script that builds a [Composer](https://github.com/mosaicml/composer) Trainer and calls `trainer.fit()`.
+* `src/models/mosaic_gpt/` - a simple PyTorch GPT model, wrapped in `ComposerModel`, that can scale up to 70B+ parameters
+* `main.py` - a training script that builds a [Composer](https://github.com/mosaicml/composer) Trainer and calls `trainer.fit()`.
 * `yamls/` - configs for training compute-optimal LLMs from 125M up to 70B parameters.
-* `throughput/` - data on the throughput of our models on different cluster configurations.
-* `mcloud/` - examples of how to use [MosaicML platform](https://www.mosaicml.com/platform) to seamlessly launch training :)
+* `throughput/` - data on the training throughput of our models on different cluster configurations.
+* `inference/` - TBD
+* `mcloud/` - examples of how to use [MosaicML platform](https://www.mosaicml.com/platform) to seamlessly launch training, eval, and inference jobs :)
 
 
 In the [common](../common) folder, you will also find:
+* `common/builders.py`-
 * `common/text_data.py`- a [MosaicML streaming dataset](https://streaming.docs.mosaicml.com/en/stable/) that can be used with a vanilla PyTorch dataloader.
+* `common/convert_dataset.py`- an example of converting generic text data into StreamingDataset `.mds` shard files.
 
 At all model scales, we are training the exact same [vanilla PyTorch GPT model](./src/mosaic_gpt.py#L106), with no special parallelism strategies.
 Composer + FSDP does all the heavy lifting to make sure we can scale up without running out of memory and while maintaining high performance.
@@ -193,7 +196,7 @@ by using [Composer's logging integrations](https://docs.mosaicml.com/en/stable/t
 
 # How many GPUs do I need to train a LLM?
 This is a complicated question in general, but if we assume that you are using FSDP with `FULL_SHARD`,
-activation checkpointing, but NOT `cpu_offload` (coming soon!), then a good rule of thumb is:
+activation checkpointing, and DecoupledAdamW, then a good rule of thumb is:
 
 > Your total cluster memory in GB should be larger than  16 * N (# billions of params).
 

--- a/examples/llm/inference/README.md
+++ b/examples/llm/inference/README.md
@@ -1,13 +1,13 @@
 # LLM Inference
 
-This folder contains helper scripts for exporting and generating outputs with  your Composer-trained LLMs.
+This folder contains helper scripts for exporting and generating outputs with your Composer-trained LLMs.
 
 
-## Converting a Composer checkpoint to a HF checkpoint folder
+## Converting a Composer checkpoint to an HF checkpoint folder
 
-The LLMs trained with this codebase are all HuggingFace (HF) PretrainedModels, which we wrap with a `HuggingFaceModel` wrapper class to make compatible with Composer. See details [here](https://docs.mosaicml.com/en/latest/examples/pretrain_finetune_huggingface.html).
+The LLMs trained with this codebase are all HuggingFace (HF) `PreTrainedModel`s, which we wrap with a `HuggingFaceModel` wrapper class to make compatible with Composer. See [docs](https://docs.mosaicml.com/en/latest/api_reference/generated/composer.models.HuggingFaceModel.html) and an [example](https://docs.mosaicml.com/en/latest/examples/pretrain_finetune_huggingface.html) for more details.
 
-At the end of your training runs, you will see a collection of Composer trainer checkpoints such as `ep0-ba2000-rank0.pt`. These checkpoints contain the entire training state, including the model, tokenizer, optimizer state, schedulers, timestamp, metrics, etc. Though these Composer checkpoints are useful during training, at inference time we usually just want the model, tokenizer, and metadata.
+At the end of your training runs, you will see a collection of Composer `Trainer` checkpoints such as `ep0-ba2000-rank0.pt`. These checkpoints contain the entire training state, including the model, tokenizer, optimizer state, schedulers, timestamp, metrics, etc. Though these Composer checkpoints are useful during training, at inference time we usually just want the model, tokenizer, and metadata.
 
 To extract these pieces, we provide a script `convert_composer_to_hf.py` that converts a Composer checkpoint directly to a standard HF checkpoint folder. For example:
 ```bash
@@ -34,7 +34,7 @@ If you trained and saved a custom HF model such as `MosaicGPT`, then in any exte
 
 ```python
 # MosaicGPT, MosaicGPTConfig source code live in this repo
-# pip install mosaicml-examples
+# pip install <my-awesome-repo>
 
 from examples.llm import MosaicGPT, MosaicGPTConfig
 
@@ -92,7 +92,7 @@ The answer to life, the universe, and happiness is to love.
 
 ...
 ##################################################################
-MosaicML is an ML training efficiency starup that is known for its efficient and efficient strategies.
+MosaicML is an ML training efficiency startup that is known for its efficient and efficient strategies.
 
 ...
 ##################################################################
@@ -133,4 +133,4 @@ python inference/convert_hf_to_onnx.py --pretrained_model_name_or_path local/pat
 python inference/convert_hf_to_onnx.py --pretrained_model_name_or_path local/path/to/huggingface/folder --output_folder local/folder --export_batch_size 1 --max_seq_len 32000
 ```
 
-Please raise a Github issue if you discover any problems!
+Please open a Github issue if you discover any problems!

--- a/examples/llm/inference/README.md
+++ b/examples/llm/inference/README.md
@@ -57,12 +57,12 @@ python hf_generate.py \
     --temperature 1.0 \
     --top_p 0.95 \
     --top_k 50 \
-    --seed 1 \
+    --seed 17 \
     --max_new_tokens 256 \
     --prompts \
       "The answer to life, the universe, and happiness is" \
-      "MosaicML is an ML training efficiency starup that is known for" \
-      "My name is" \
+      "MosaicML is an ML training efficiency startup that is known for" \
+      "Here's a quick recipe for baking chocolate chip cookies: Start by" \
       "The best 5 cities to visit in Europe are"
 ```
 
@@ -75,6 +75,8 @@ n_params=124439808
 Loading HF tokenizer...
 /mnt/workdisk/abhi/examples/examples/llm/inference/hf_generate.py:89: UserWarning: pad_token_id is not set for the tokenizer. Using eos_token_id as pad_token_id.
   warnings.warn(
+Setting `pad_token_id` to `eos_token_id`:50256 for open-end generation.
+Setting `pad_token_id` to `eos_token_id`:50256 for open-end generation.
 
 Generate kwargs:
 {'max_new_tokens': 256, 'temperature': 1.0, 'top_p': 0.95, 'top_k': 50, 'use_cache': True, 'do_sample': True, 'eos_token_id': 50256}
@@ -84,31 +86,21 @@ Moving model and inputs to device=cuda and dtype=torch.bfloat16...
 Tokenizing prompts...
 NOT using autocast...
 Warming up...
-Setting `pad_token_id` to `eos_token_id`:50256 for open-end generation.
 Generating responses...
-Setting `pad_token_id` to `eos_token_id`:50256 for open-end generation.
-##################################################################
-The answer to life, the universe, and happiness is to love.
-
-...
-##################################################################
-MosaicML is an ML training efficiency startup that is known for its efficient and efficient strategies.
-
-...
-##################################################################
-My name is Eulogy Jackson, and I am the mother of nine children.
-
-...
-##################################################################
-The best 5 cities to visit in Europe are the one in Spain (Spain) and the one in Holland (Belgium).
-
-...
-##################################################################
-bs=4, input_tokens=array([11, 15,  3,  9]), output_tokens=array([256, 256, 256, 256])
-total_input_tokens=38, total_output_tokens=1024
-encode_latency=78.04ms, gen_latency=2615.56ms, decode_latency=2.28ms, total_latency=2695.89ms
-latency_per_output_token=2.63ms/tok
-output_tok_per_sec=379.84tok/sec
+####################################################################################################
+The answer to life, the universe, and happiness is to love...
+####################################################################################################
+MosaicML is an ML training efficiency startup that is known for designing and developing applications to improve training and performance efficiency...
+####################################################################################################
+Here\'s a quick recipe for baking chocolate chip cookies: Start by making an apple crumble by yourself or bake in the microwave for 40 minutes to melt and get melted...
+####################################################################################################
+The best 5 cities to visit in Europe are the one in Spain (Spain) and the one in Holland (Belgium)...
+####################################################################################################
+bs=4, input_tokens=array([11, 14, 13,  9]), output_tokens=array([256, 256, 256,  41])
+total_input_tokens=47, total_output_tokens=809
+encode_latency=9.56ms, gen_latency=2759.02ms, decode_latency=1.72ms, total_latency=2770.31ms
+latency_per_output_token=3.42ms/tok
+output_tok_per_sec=292.03tok/sec
 ```
 
 The argument for `--name_or_path` can be either the name of a model that exists on the HF Hub, such as `gpt2`, `facebook/opt-350m`, etc. or the path to a HF checkpoint folder, such as `my_hf_model/` like we exported above.

--- a/examples/llm/inference/README.md
+++ b/examples/llm/inference/README.md
@@ -57,7 +57,7 @@ python hf_generate.py \
     --temperature 1.0 \
     --top_p 0.95 \
     --top_k 50 \
-    --seed 17 \
+    --seed 1 \
     --max_new_tokens 256 \
     --prompts \
       "The answer to life, the universe, and happiness is" \

--- a/examples/llm/inference/README.md
+++ b/examples/llm/inference/README.md
@@ -1,0 +1,136 @@
+# LLM Inference
+
+This folder contains helper scripts for exporting and generating outputs with  your Composer-trained LLMs.
+
+
+## Converting a Composer checkpoint to a HF checkpoint folder
+
+The LLMs trained with this codebase are all HuggingFace (HF) PretrainedModels, which we wrap with a `HuggingFaceModel` wrapper class to make compatible with Composer. See details [here](https://docs.mosaicml.com/en/latest/examples/pretrain_finetune_huggingface.html).
+
+At the end of your training runs, you will see a collection of Composer trainer checkpoints such as `ep0-ba2000-rank0.pt`. These checkpoints contain the entire training state, including the model, tokenizer, optimizer state, schedulers, timestamp, metrics, etc. Though these Composer checkpoints are useful during training, at inference time we usually just want the model, tokenizer, and metadata.
+
+To extract these pieces, we provide a script `convert_composer_to_hf.py` that converts a Composer checkpoint directly to a standard HF checkpoint folder. For example:
+```bash
+python convert_composer_to_hf.py --composer_path ep0-ba2000-rank0.pt --hf_output_path my_hf_model/ --output_precision bf16
+```
+
+This will produce a folder like:
+```
+my_hf_model/
+  config.json
+  merges.txt
+  pytorch_model.bin
+  special_tokens_map.json
+  tokenizer.json
+  tokenizer_config.json
+  vocab.json
+```
+which can be loaded with standard HF utilities like `AutoModelForCausalLM.from_pretrained('my_hf_model')`.
+
+You can also pass object store URIs for both `--composer_path` and `--hf_output_path` to easily convert checkpoints stored in S3, OCI, etc.
+
+### IMPORTANT NOTE:
+If you trained and saved a custom HF model such as `MosaicGPT`, then in any external inference codebase, you need to import and register the new model class and config before auto classes like `AutoModel` will work. For example:
+
+```python
+# MosaicGPT, MosaicGPTConfig source code live in this repo
+# pip install mosaicml-examples
+
+from examples.llm import MosaicGPT, MosaicGPTConfig
+
+AutoConfig.register('mosaic_gpt', MosaicGPTConfig)
+AutoModelForCausalLM.register(MosaicGPTConfig, MosaicGPT)
+
+model = AutoModelForCausalLM.from_pretrained('my_hf_model')
+```
+
+(Coming soon) we will add the ability to save custom model source code within the HF folder, which will remove the need for this step!
+
+
+## Interactive generation with `model.generate(...)`
+
+To make it easy to inspect the generations produced by your HF model, we include a script `hf_generate.py` that allows you to run custom prompts through your HF model, like so:
+
+```bash
+python hf_generate.py \
+    --name_or_path gpt2 \
+    --temperature 1.0 \
+    --top_p 0.95 \
+    --top_k 50 \
+    --seed 1 \
+    --max_new_tokens 256 \
+    --prompts \
+      "The answer to life, the universe, and happiness is" \
+      "MosaicML is an ML training efficiency starup that is known for" \
+      "My name is" \
+      "The best 5 cities to visit in Europe are"
+```
+
+which will produce output:
+
+```bash
+Loading HF model...
+n_params=124439808
+
+Loading HF tokenizer...
+/mnt/workdisk/abhi/examples/examples/llm/inference/hf_generate.py:89: UserWarning: pad_token_id is not set for the tokenizer. Using eos_token_id as pad_token_id.
+  warnings.warn(
+
+Generate kwargs:
+{'max_new_tokens': 256, 'temperature': 1.0, 'top_p': 0.95, 'top_k': 50, 'use_cache': True, 'do_sample': True, 'eos_token_id': 50256}
+
+Moving model and inputs to device=cuda and dtype=torch.bfloat16...
+
+Tokenizing prompts...
+NOT using autocast...
+Warming up...
+Setting `pad_token_id` to `eos_token_id`:50256 for open-end generation.
+Generating responses...
+Setting `pad_token_id` to `eos_token_id`:50256 for open-end generation.
+##################################################################
+The answer to life, the universe, and happiness is to love.
+
+...
+##################################################################
+MosaicML is an ML training efficiency starup that is known for its efficient and efficient strategies.
+
+...
+##################################################################
+My name is Eulogy Jackson, and I am the mother of nine children.
+
+...
+##################################################################
+The best 5 cities to visit in Europe are the one in Spain (Spain) and the one in Holland (Belgium).
+
+...
+##################################################################
+bs=4, input_tokens=array([11, 15,  3,  9]), output_tokens=array([256, 256, 256, 256])
+total_input_tokens=38, total_output_tokens=1024
+encode_latency=78.04ms, gen_latency=2615.56ms, decode_latency=2.28ms, total_latency=2695.89ms
+latency_per_output_token=2.63ms/tok
+output_tok_per_sec=379.84tok/sec
+```
+
+The argument for `--name_or_path` can be either the name of a model that exists on the HF Hub, such as `gpt2`, `facebook/opt-350m`, etc. or the path to a HF checkpoint folder, such as `my_hf_model/` like we exported above.
+
+## Converting your HF model to ONNX
+
+We include a script `convert_hf_to_onnx.py` that demonstrates how to convert your HF model to ONNX format. For more details and examples
+of exporting and working with HuggingFace models with ONNX, see https://huggingface.co/docs/transformers/serialization#export-to-onnx.
+
+Here a couple examples of using the script:
+```bash
+# 1) Local export
+python inference/convert_hf_to_onnx.py --pretrained_model_name_or_path local/path/to/huggingface/folder --output_folder local/folder
+
+# 2) Remote export
+python inference/convert_hf_to_onnx.py --pretrained_model_name_or_path local/path/to/huggingface/folder --output_folder s3://bucket/remote/folder
+
+# 3) Verify the exported model
+python inference/convert_hf_to_onnx.py --pretrained_model_name_or_path local/path/to/huggingface/folder --output_folder local/folder --verify_export
+
+# 4) Change the batch size or max sequence length
+python inference/convert_hf_to_onnx.py --pretrained_model_name_or_path local/path/to/huggingface/folder --output_folder local/folder --export_batch_size 1 --max_seq_len 32000
+```
+
+Please raise a Github issue if you discover any problems!

--- a/examples/llm/inference/convert_composer_to_hf.py
+++ b/examples/llm/inference/convert_composer_to_hf.py
@@ -67,6 +67,7 @@ def get_hf_tokenizer_from_composer_state_dict(
 def write_huggingface_pretrained_from_composer_checkpoint(
         checkpoint_path: Union[Path, str],
         output_path: Union[Path, str],
+        output_precision: str = 'fp32',
         local_checkpoint_save_location: Optional[Union[Path,
                                                        str]] = None) -> None:
     """Convert a Composer checkpoint to a pretrained HF checkpoint folder.
@@ -107,6 +108,7 @@ def write_huggingface_pretrained_from_composer_checkpoint(
             supported by :meth:`composer.utils.maybe_create_object_store_from_uri`.
         output_path (Union[Path, str]): Path to the folder to write the output to. Can be a local path, or a remote path beginning with ``s3://``, or another backend
             supported by :meth:`composer.utils.maybe_create_object_store_from_uri`.
+        output_precision (str, optional): The precision of the output weights saved to `pytorch_model.bin`. Can be one of ``fp32``, ``fp16``, or ``fp32``.
         local_checkpoint_save_location (Optional[Union[Path, str]], optional): If specified, where to save the checkpoint file to locally.
                                                                                 If the input ``checkpoint_path`` is already a local path, this will be a symlink.
                                                                                 Defaults to None, which will use a temporary file.
@@ -155,7 +157,7 @@ def write_huggingface_pretrained_from_composer_checkpoint(
     else:
         print('Warning! No HF Tokenizer found!')
 
-    # Extract and save the HF model weights
+    # Extract the HF model weights
     print('#' * 30)
     print('Saving HF Model Weights...')
     weights_state_dict = composer_state_dict
@@ -163,6 +165,18 @@ def write_huggingface_pretrained_from_composer_checkpoint(
         weights_state_dict = weights_state_dict['state']['model']
     torch.nn.modules.utils.consume_prefix_in_state_dict_if_present(
         weights_state_dict, prefix='model.')
+
+    # Convert weights to desired dtype
+    dtype = {
+        'fp32': torch.float32,
+        'fp16': torch.float16,
+        'bf16': torch.bfloat16,
+    }[output_precision]
+    for k, v in weights_state_dict.items():
+        if isinstance(v, torch.Tensor):
+            weights_state_dict[k] = v.to(dtype=dtype)
+
+    # Save weights
     torch.save(weights_state_dict,
                Path(local_output_path) / 'pytorch_model.bin')
 
@@ -193,6 +207,10 @@ def parse_args() -> Namespace:
     parser.add_argument('--local_checkpoint_save_location',
                         type=str,
                         default=None)
+    parser.add_argument('--output_precision',
+                        type=str,
+                        choices=['fp32', 'fp16', 'bf16'],
+                        default='fp32')
 
     return parser.parse_args()
 
@@ -201,6 +219,7 @@ def main(args: Namespace) -> None:
     write_huggingface_pretrained_from_composer_checkpoint(
         checkpoint_path=args.composer_path,
         output_path=args.hf_output_path,
+        output_precision=args.output_precision,
         local_checkpoint_save_location=args.local_checkpoint_save_location)
 
 

--- a/examples/llm/inference/convert_composer_to_hf.py
+++ b/examples/llm/inference/convert_composer_to_hf.py
@@ -108,7 +108,7 @@ def write_huggingface_pretrained_from_composer_checkpoint(
             supported by :meth:`composer.utils.maybe_create_object_store_from_uri`.
         output_path (Union[Path, str]): Path to the folder to write the output to. Can be a local path, or a remote path beginning with ``s3://``, or another backend
             supported by :meth:`composer.utils.maybe_create_object_store_from_uri`.
-        output_precision (str, optional): The precision of the output weights saved to `pytorch_model.bin`. Can be one of ``fp32``, ``fp16``, or ``fp32``.
+        output_precision (str, optional): The precision of the output weights saved to `pytorch_model.bin`. Can be one of ``fp32``, ``fp16``, or ``bf16``.
         local_checkpoint_save_location (Optional[Union[Path, str]], optional): If specified, where to save the checkpoint file to locally.
                                                                                 If the input ``checkpoint_path`` is already a local path, this will be a symlink.
                                                                                 Defaults to None, which will use a temporary file.

--- a/examples/llm/inference/hf_generate.py
+++ b/examples/llm/inference/hf_generate.py
@@ -50,6 +50,7 @@ def parse_args() -> Namespace:
                         const=True,
                         default=True)
     parser.add_argument('--eos_token_id', type=str, default=None)
+    parser.add_argument('--pad_token_id', type=str, default=None)
     parser.add_argument('--dtype',
                         type=str,
                         choices=['fp32', 'fp16', 'bf16'],
@@ -99,7 +100,8 @@ def main(args: Namespace) -> None:
         'top_k': args.top_k,
         'use_cache': args.use_cache,
         'do_sample': args.do_sample,
-        'eos_token_id': args.eos_token_id or tokenizer.eos_token_id
+        'eos_token_id': args.eos_token_id or tokenizer.eos_token_id,
+        'pad_token_id': args.pad_token_id or tokenizer.pad_token_id,
     }
     print(f'\nGenerate kwargs:\n{generate_kwargs}')
 

--- a/examples/llm/mcloud/mcli-convert-composer-to-hf.yaml
+++ b/examples/llm/mcloud/mcli-convert-composer-to-hf.yaml
@@ -11,7 +11,7 @@ command: |
   python convert_composer_to_hf.py \
     --composer_path s3://bucket/folder/checkpoint-path.pt \
     --hf_output_path s3://bucket/folder/hf/ \
-    --precision bf16 \
+    --output_precision bf16 \
 
 image: mosaicml/pytorch:1.13.1_cu117-python3.10-ubuntu20.04
 optimization_level: 0

--- a/examples/llm/mcloud/mcli-convert-composer-to-hf.yaml
+++ b/examples/llm/mcloud/mcli-convert-composer-to-hf.yaml
@@ -10,7 +10,8 @@ command: |
   cd examples/examples/llm/inference
   python convert_composer_to_hf.py \
     --composer_path s3://bucket/folder/checkpoint-path.pt \
-    --hf_output_path s3://bucket/folder/hf/
+    --hf_output_path s3://bucket/folder/hf/ \
+    --precision bf16 \
 
 image: mosaicml/pytorch:1.13.1_cu117-python3.10-ubuntu20.04
 optimization_level: 0

--- a/examples/llm/mcloud/mcli-hf-generate.yaml
+++ b/examples/llm/mcloud/mcli-hf-generate.yaml
@@ -19,8 +19,8 @@ command: |
     --max_new_tokens 256 \
     --prompts \
       "The answer to life, the universe, and happiness is" \
-      "MosaicML is an ML training efficiency starup that is known for" \
-      "My name is" \
+      "MosaicML is an ML training efficiency startup that is known for" \
+      "Here's a quick recipe for baking chocolate chip cookies: Start by" \
       "The best 5 cities to visit in Europe are"
 
 image: mosaicml/pytorch:1.13.1_cu117-python3.10-ubuntu20.04

--- a/examples/llm/mcloud/mcli-hf-generate.yaml
+++ b/examples/llm/mcloud/mcli-hf-generate.yaml
@@ -12,7 +12,16 @@ command: |
   aws s3 cp --recursive s3://bucket/folder/hf/ local_hf_folder
   python hf_generate.py \
     --name_or_path local_hf_folder \
-    --max_new_tokens 512
+    --temperature 1.0 \
+    --top_p 0.95 \
+    --top_k 50 \
+    --seed 1 \
+    --max_new_tokens 256 \
+    --prompts \
+      "The answer to life, the universe, and happiness is" \
+      "MosaicML is an ML training efficiency starup that is known for" \
+      "My name is" \
+      "The best 5 cities to visit in Europe are"
 
 image: mosaicml/pytorch:1.13.1_cu117-python3.10-ubuntu20.04
 optimization_level: 0


### PR DESCRIPTION
This PR adds a README to `llm/inference/README.md` and also updates some additional READMEs.

It also adds an `--output_precision` argument for saving HF model weights, and I verified that it still works with `hf_generate.py`.

TODO: continue cleaning up READMEs...