### PR TITLE
Add example code to download huggingface checkpoint from OCI for generate 

### DIFF
--- a/examples/llm/mcloud/mcli-hf-generate.yaml
+++ b/examples/llm/mcloud/mcli-hf-generate.yaml
@@ -13,7 +13,7 @@ command: |
   pip install awscli
   aws s3 cp --recursive s3://bucket/folder/hf/ local_hf_folder
 
-  # # oci commands
+  # oci commands
   # pip install oci-cli
   # oci os object bulk-download \
   # -bn bucket --region bucket_region \

--- a/examples/llm/mcloud/mcli-hf-generate.yaml
+++ b/examples/llm/mcloud/mcli-hf-generate.yaml
@@ -8,7 +8,7 @@ integrations:
 
 command: |
   cd examples/examples/llm/inference
-  
+
   # s3 commands
   pip install awscli
   aws s3 cp --recursive s3://bucket/folder/hf/ local_hf_folder

--- a/examples/llm/mcloud/mcli-hf-generate.yaml
+++ b/examples/llm/mcloud/mcli-hf-generate.yaml
@@ -8,8 +8,20 @@ integrations:
 
 command: |
   cd examples/examples/llm/inference
+  
+  # s3 commands
   pip install awscli
   aws s3 cp --recursive s3://bucket/folder/hf/ local_hf_folder
+
+  # # oci commands
+  # pip install oci-cli
+  # oci os object bulk-download \
+  # -bn YOUR_BUCKET_HERE  --region BUCKET_REGION \
+  # --prefix folder/hf/ --dest-dir ./
+  # # oci downloads the full prefix path, this extracts the innermost folder
+  # # into local_hf_folder
+  # mv folder/hf/ local_hf_folder
+
   python hf_generate.py \
     --name_or_path local_hf_folder \
     --temperature 1.0 \

--- a/examples/llm/mcloud/mcli-hf-generate.yaml
+++ b/examples/llm/mcloud/mcli-hf-generate.yaml
@@ -16,7 +16,7 @@ command: |
   # # oci commands
   # pip install oci-cli
   # oci os object bulk-download \
-  # -bn YOUR_BUCKET_HERE  --region BUCKET_REGION \
+  # -bn bucket --region bucket_region \
   # --prefix folder/hf/ --dest-dir ./
   # # oci downloads the full prefix path, this extracts the innermost folder
   # # into local_hf_folder


### PR DESCRIPTION
This PR shows a commented-out snippet of downloading hf checkpoint from OCI. The only caveat is that `bulk-download` downloads the entire prefix tree, so this adds a `mv` to be consistent with s3.