### PR TITLE
updt flash attn version

### DIFF
--- a/examples/llm/requirements.txt
+++ b/examples/llm/requirements.txt
@@ -2,7 +2,7 @@ torch==1.13.1
 einops==0.5.0
 mosaicml==0.13.4
 mosaicml-streaming==0.4.0
-flash-attn==0.2.8
+flash-attn==v1.0.3.post0
 mosaicml-cli>=0.2.32,<1
 # need a newer version of triton
 triton==2.0.0.dev20221202


### PR DESCRIPTION
updt flash attn version
flash attn has now changed, just the version

Issue: https://mosaicml.atlassian.net/browse/RESEARCH-639

it installs and runs on interactive instance
~I'll run~ I ran 4x 125M chinchilla convergence runs (old and new version with triton and flash attn) to verify nothing changed ([wandb](https://wandb.ai/mosaic-ml/test_flash_updt))

<img width="500" alt="Screenshot 2023-04-25 at 2 34 00 PM" src="https://user-images.githubusercontent.com/6439018/234409183-9da85d7d-60db-4be2-af75-12626423c17a.png">
The 4 curves are near identical.