### PR TITLE
Update hf-bert-base-uncased.yaml

### DIFF
--- a/examples/bert/yamls/main/hf-bert-base-uncased.yaml
+++ b/examples/bert/yamls/main/hf-bert-base-uncased.yaml
@@ -79,7 +79,7 @@ seed: 17
 device_eval_batch_size: 128
 device_train_microbatch_size: 128
 # device_train_microbatch_size: auto
-precision: bf16
+precision: amp_bf16
 
 # Logging
 progress_bar: false

--- a/examples/bert/yamls/main/mosaic-bert-base-uncased.yaml
+++ b/examples/bert/yamls/main/mosaic-bert-base-uncased.yaml
@@ -80,7 +80,7 @@ seed: 17
 device_eval_batch_size: 128
 device_train_microbatch_size: 128
 # device_train_microbatch_size: auto
-precision: bf16
+precision: amp_bf16
 
 # Logging
 progress_bar: false


### PR DESCRIPTION
change precision from bf16 to amp_bf16. This was something caught by a user here https://github.com/mosaicml/examples/issues/321. Since this is passed directly to the Composer trainer, I believe it needs to be one of the following options `fp32`, `amp_fp16`, `amp_bf16`, `amp_fp8` https://github.com/mosaicml/composer/blob/457717427e4d84f645e04fd801e79ab45fd26877/composer/core/precision.py#L24