### PR TITLE
MPT Handler Predict Fix

### DIFF
--- a/examples/inference_model_handlers/mpt/mpt_7b_handler.py
+++ b/examples/inference_model_handlers/mpt/mpt_7b_handler.py
@@ -93,7 +93,10 @@ class MPTModelHandler():
         
         print("Logging input to generate: ", generate_inputs)
         outputs = self.generator(generate_inputs, **generate_kwargs)
-        return self._extract_output(outputs)
+        print(outputs)
+        ret = self._extract_output(outputs)
+        print(ret)
+        return ret
 
     def predict_stream(self, **inputs: Dict[str, Any]):
         generate_input, generate_kwargs = self._parse_inputs(inputs)

--- a/examples/inference_model_handlers/mpt/mpt_7b_handler.py
+++ b/examples/inference_model_handlers/mpt/mpt_7b_handler.py
@@ -1,6 +1,6 @@
 import copy
 from threading import Thread
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import torch
 from transformers import (AutoConfig, AutoModelForCausalLM, AutoTokenizer,
@@ -63,11 +63,37 @@ class MPTModelHandler():
                 generate_kwargs[k] = v
 
         return generate_input, generate_kwargs
+    
+    def _extract_output(self, outputs: List[Any]):
+        output_bytes_list = []
+        for output in outputs:
+            output_bytes = bytes(output[0]['generated_text'], encoding='utf8')
+            output_bytes_list.append(output_bytes)
+        return output_bytes_list
 
-    def predict(self, **inputs: Dict[str, Any]):
-        generate_input, generate_kwargs = self._parse_inputs(inputs)
-        outputs = self.generator(generate_input, **generate_kwargs)
-        return [output[0]['generated_text'] for output in outputs]
+    def predict(self, input_dicts):
+        print(input_dicts)
+        generate_inputs = []
+        generate_kwargs = {}
+        for input_dict in input_dicts:            
+            generate_input_list, generate_kwarg = self._parse_inputs(
+                input_dict
+            )
+            # Flatten the list of inputs into a single list
+            # 2 cases for batching 
+            # 1. Multiple requests single input string
+            # 2. Single request multiple input strings
+            generate_inputs += generate_input_list
+            
+            for k, v in generate_kwarg.items(): 
+                if k in generate_kwargs and generate_kwargs[k] != v:
+                    raise RuntimeError(f"Request has conflicting values for kwarg {k}")
+                generate_kwargs[k] = v 
+        
+        
+        print("Logging input to generate: ", generate_inputs)
+        outputs = self.generator(generate_inputs, **generate_kwargs)
+        return self._extract_output(outputs)
 
     def predict_stream(self, **inputs: Dict[str, Any]):
         generate_input, generate_kwargs = self._parse_inputs(inputs)

--- a/examples/inference_model_handlers/mpt/mpt_7b_handler.py
+++ b/examples/inference_model_handlers/mpt/mpt_7b_handler.py
@@ -67,12 +67,11 @@ class MPTModelHandler():
     def _extract_output(self, outputs: List[Any]):
         output_bytes_list = []
         for output in outputs:
-            output_bytes = bytes(output[0]['generated_text'], encoding='utf8')
+            output_bytes = output[0]['generated_text']
             output_bytes_list.append(output_bytes)
         return output_bytes_list
 
-    def predict(self, input_dicts):
-        print(input_dicts)
+    def predict(self, input_dicts: List[Dict[str, Any]]):
         generate_inputs = []
         generate_kwargs = {}
         for input_dict in input_dicts:            
@@ -93,10 +92,7 @@ class MPTModelHandler():
         
         print("Logging input to generate: ", generate_inputs)
         outputs = self.generator(generate_inputs, **generate_kwargs)
-        print(outputs)
-        ret = self._extract_output(outputs)
-        print(ret)
-        return ret
+        return self._extract_output(outputs)
 
     def predict_stream(self, **inputs: Dict[str, Any]):
         generate_input, generate_kwargs = self._parse_inputs(inputs)


### PR DESCRIPTION
Predict was out of date with new server Forward method which sends a BatchedRequest with potentially multiple input dicts.
Predict now generates output for each input dict and returns list of outputs as expected by Forward. Predict was also returning output as bytes but proto Structs don't take bytes as a valid value so now predict returns output as string.