### PR TITLE
Modify model handlers to take in new request structure

### DIFF
--- a/examples/inference-deployments/instructor/instructor_handler.py
+++ b/examples/inference-deployments/instructor/instructor_handler.py
@@ -1,6 +1,6 @@
 # Copyright 2022 MosaicML Examples authors
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Dict, List
+from typing import Dict, List
 
 import torch
 from InstructorEmbedding import INSTRUCTOR
@@ -18,7 +18,7 @@ class HFInstructorHandler():
         self.model = INSTRUCTOR(self.model_name)
         self.model.to(self.device)
 
-    def predict(self, model_requests: List[Dict[str, Any]]):
+    def predict(self, model_requests: List[Dict]):
         """Runs a forward pass with the given inputs.
 
         Model request format: {"input": ["<instruction>", "<sentence>"]}

--- a/examples/inference-deployments/instructor/instructor_handler.py
+++ b/examples/inference-deployments/instructor/instructor_handler.py
@@ -27,7 +27,7 @@ class HFInstructorHandler():
         for req in model_requests:
             if 'input' not in req:
                 raise KeyError('input key not in model_requests')
-            input_list.append(input['input'])
+            input_list.append(req['input'])
 
         embeddings = self.model.encode(input_list)
         return embeddings.tolist()

--- a/examples/inference-deployments/instructor/instructor_handler.py
+++ b/examples/inference-deployments/instructor/instructor_handler.py
@@ -18,16 +18,16 @@ class HFInstructorHandler():
         self.model = INSTRUCTOR(self.model_name)
         self.model.to(self.device)
 
-    def predict(self, inputs: List[Dict[str, Any]]):
+    def predict(self, model_requests: List[Dict[str, Any]]):
         """Runs a forward pass with the given inputs.
 
-        Input format: {"input_strings": ["<instruction>", "<sentence>"]}
+        Model request format: {"input": ["<instruction>", "<sentence>"]}
         """
         input_list = []
-        for input in inputs:
-            if 'input_strings' not in input:
-                raise KeyError('input_strings key not in inputs')
-            input_list.append(input['input_strings'])
+        for req in model_requests:
+            if 'input' not in req:
+                raise KeyError('input key not in model_requests')
+            input_list.append(input['input'])
 
         embeddings = self.model.encode(input_list)
         return embeddings.tolist()

--- a/examples/inference-deployments/mpt/mpt_7b_ft_handler.py
+++ b/examples/inference-deployments/mpt/mpt_7b_ft_handler.py
@@ -8,10 +8,8 @@ import os
 from typing import Dict, List, Tuple
 
 import torch
-from FasterTransformer.examples.pytorch.gpt.utils.parallel_gpt import \
-    ParallelGPT  # type: ignore
-from scripts.inference.convert_hf_mpt_to_ft import \
-    convert_mpt_to_ft  # type: ignore
+from FasterTransformer.examples.pytorch.gpt.utils.parallel_gpt import ParallelGPT  # yapf: disable # type: ignore
+from scripts.inference.convert_hf_mpt_to_ft import convert_mpt_to_ft  # yapf: disable # type: ignore
 from torch.nn.utils.rnn import pad_sequence
 from transformers import AutoTokenizer
 

--- a/examples/inference-deployments/mpt/mpt_7b_ft_handler.py
+++ b/examples/inference-deployments/mpt/mpt_7b_ft_handler.py
@@ -200,10 +200,7 @@ class MPTFTModelHandler:
                                                            size=[batch_size],
                                                            dtype=torch.int64)
 
-    def _parse_model_requests(
-            self,
-            model_requests: List[Dict[str,
-                                      Any]]) -> Tuple[str, Dict[str, Any]]:
+    def _parse_model_requests(self, model_requests: List[Dict[str, Any]]) -> Tuple[str, Dict[str, Any]]:
         """Splits model requests into a flat list of inputs and merged kwargs."""
         generate_inputs = []
         generate_kwargs = {}

--- a/examples/inference-deployments/mpt/mpt_7b_ft_handler.py
+++ b/examples/inference-deployments/mpt/mpt_7b_ft_handler.py
@@ -5,13 +5,11 @@ import argparse
 import configparser
 import copy
 import os
-from typing import Any, Dict, List, Tuple
+from typing import Dict, List, Tuple
 
 import torch
-# isort: skip # type: ignore
 from FasterTransformer.examples.pytorch.gpt.utils.parallel_gpt import \
     ParallelGPT
-# isort: skip # type: ignore
 from scripts.inference.convert_hf_mpt_to_ft import convert_mpt_to_ft
 from torch.nn.utils.rnn import pad_sequence
 from transformers import AutoTokenizer
@@ -142,11 +140,10 @@ class MPTFTModelHandler:
                                                        trust_remote_code=True)
         print('FT initialization complete')
 
-    def _parse_model_request(
-            self, model_request: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
+    def _parse_model_request(self, model_request: Dict) -> Tuple[str, Dict]:
         if self.INPUT_KEY not in model_request:
             raise RuntimeError(
-                f'{self.INPUT_KEY} must be provided to generate call')
+                f'"{self.INPUT_KEY}" must be provided to generate call')
 
         generate_input = model_request[self.INPUT_KEY]
 
@@ -159,7 +156,7 @@ class MPTFTModelHandler:
         return generate_input, generate_kwargs
 
     def _convert_kwargs(self, generate_inputs: List[str],
-                        generate_kwargs: Dict[str, Any]):
+                        generate_kwargs: Dict):
         """Converts generate_kwargs into required torch types."""
         batch_size = len(generate_inputs)
 
@@ -198,9 +195,7 @@ class MPTFTModelHandler:
                                                            dtype=torch.int64)
 
     def _parse_model_requests(
-        self,
-        model_requests: List[Dict[str,
-                                  Any]]) -> Tuple[List[str], Dict[str, Any]]:
+            self, model_requests: List[Dict]) -> Tuple[List[str], Dict]:
         """Splits requests into a flat list of inputs and merged kwargs."""
         generate_inputs = []
         generate_kwargs = {}
@@ -216,7 +211,7 @@ class MPTFTModelHandler:
 
         return generate_inputs, generate_kwargs
 
-    def predict(self, model_requests: List[Dict[str, Any]]) -> List[str]:
+    def predict(self, model_requests: List[Dict]) -> List[str]:
         generate_inputs, generate_kwargs = self._parse_model_requests(
             model_requests)
         self._convert_kwargs(generate_inputs, generate_kwargs)
@@ -244,7 +239,7 @@ class MPTFTModelHandler:
                 outputs.append(output)
         return outputs
 
-    def predict_stream(self, **model_requests: Dict[str, Any]):
+    def predict_stream(self, **model_requests: Dict):
         raise RuntimeError('Streaming is not supported with FasterTransformer!')
 
 

--- a/examples/inference-deployments/mpt/mpt_7b_ft_handler.py
+++ b/examples/inference-deployments/mpt/mpt_7b_ft_handler.py
@@ -146,7 +146,7 @@ class MPTFTModelHandler:
             self, model_request: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
         if self.INPUT_KEY not in model_request:
             raise RuntimeError(
-                f"{self.INPUT_KEY} must be provided to generate call")
+                f'{self.INPUT_KEY} must be provided to generate call')
 
         generate_input = model_request[self.INPUT_KEY]
 
@@ -201,7 +201,7 @@ class MPTFTModelHandler:
         self,
         model_requests: List[Dict[str,
                                   Any]]) -> Tuple[List[str], Dict[str, Any]]:
-        """Splits model requests into a flat list of inputs and merged kwargs."""
+        """Splits requests into a flat list of inputs and merged kwargs."""
         generate_inputs = []
         generate_kwargs = {}
         for req in model_requests:
@@ -245,8 +245,7 @@ class MPTFTModelHandler:
         return outputs
 
     def predict_stream(self, **model_requests: Dict[str, Any]):
-        raise RuntimeError(
-            'Streaming is not supported with FasterTransformer!')
+        raise RuntimeError('Streaming is not supported with FasterTransformer!')
 
 
 if __name__ == '__main__':
@@ -257,13 +256,15 @@ if __name__ == '__main__':
         '--ft_lib_path',
         type=str,
         required=True,
-        help='Path to the libth_transformer dynamic lib file(e.g., build/lib/libth_transformer.so.'
+        help=
+        'Path to the libth_transformer dynamic lib file(e.g., build/lib/libth_transformer.so.'
     )
     parser.add_argument(
         '--name_or_dir',
         '-i',
         type=str,
-        help='HF hub Model name (e.g., mosaicml/mpt-7b) or local dir path to load checkpoint from',
+        help=
+        'HF hub Model name (e.g., mosaicml/mpt-7b) or local dir path to load checkpoint from',
         required=True)
     parser.add_argument('--inference_data_type',
                         '--data_type',
@@ -275,7 +276,8 @@ if __name__ == '__main__':
         type=int,
         default=0,
         choices=[0, 1],
-        help='The level of quantization to perform. 0: No quantization. All computation in data_type. 1: Quantize weights to int8, all compute occurs in fp16/bf16. Not supported when data_type is fp32'
+        help=
+        'The level of quantization to perform. 0: No quantization. All computation in data_type. 1: Quantize weights to int8, all compute occurs in fp16/bf16. Not supported when data_type is fp32'
     )
     parser.add_argument('--gpus',
                         type=int,

--- a/examples/inference-deployments/mpt/mpt_7b_ft_handler.py
+++ b/examples/inference-deployments/mpt/mpt_7b_ft_handler.py
@@ -9,9 +9,9 @@ from typing import Dict, List, Tuple
 
 import torch
 from FasterTransformer.examples.pytorch.gpt.utils.parallel_gpt import \
-    ParallelGPT  # pyright: ignore
+    ParallelGPT  # type: ignore
 from scripts.inference.convert_hf_mpt_to_ft import \
-    convert_mpt_to_ft  # pyright: ignore
+    convert_mpt_to_ft  # type: ignore
 from torch.nn.utils.rnn import pad_sequence
 from transformers import AutoTokenizer
 

--- a/examples/inference-deployments/mpt/mpt_7b_ft_handler.py
+++ b/examples/inference-deployments/mpt/mpt_7b_ft_handler.py
@@ -210,7 +210,7 @@ class MPTFTModelHandler:
         for req in model_requests:
             generate_input, generate_kwarg = self._parse_model_request(
                 req)
-            generate_inputs += generate_input
+            generate_inputs += [generate_input]
 
             for k, v in generate_kwarg.items():
                 if k in generate_kwargs and generate_kwargs[k] != v:

--- a/examples/inference-deployments/mpt/mpt_7b_ft_handler.py
+++ b/examples/inference-deployments/mpt/mpt_7b_ft_handler.py
@@ -8,14 +8,13 @@ import os
 from typing import Any, Dict, List, Tuple
 
 import torch
-from torch.nn.utils.rnn import pad_sequence
-from transformers import AutoTokenizer
-
 # isort: skip # type: ignore
-from FasterTransformer.examples.pytorch.gpt.utils.parallel_gpt import ParallelGPT
-
+from FasterTransformer.examples.pytorch.gpt.utils.parallel_gpt import \
+    ParallelGPT
 # isort: skip # type: ignore
 from scripts.inference.convert_hf_mpt_to_ft import convert_mpt_to_ft
+from torch.nn.utils.rnn import pad_sequence
+from transformers import AutoTokenizer
 
 LOCAL_CHECKPOINT_PATH = '/tmp/mpt'
 
@@ -143,7 +142,8 @@ class MPTFTModelHandler:
                                                        trust_remote_code=True)
         print('FT initialization complete')
 
-    def _parse_model_request(self, model_request: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
+    def _parse_model_request(
+            self, model_request: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
         if self.INPUT_KEY not in model_request:
             raise RuntimeError(
                 f"{self.INPUT_KEY} must be provided to generate call")
@@ -152,9 +152,6 @@ class MPTFTModelHandler:
 
         # Set default generate kwargs
         generate_kwargs = copy.deepcopy(self.DEFAULT_GENERATE_KWARGS)
-        # TODO any reason why we don't need this?:
-        # generate_kwargs['eos_token_id'] = self.tokenizer.eos_token_id
-
         # If request contains any additional kwargs, add them to generate_kwargs
         for k, v in model_request.get(self.PARAMETERS_KEY, {}).items():
             generate_kwargs[k] = v
@@ -200,13 +197,15 @@ class MPTFTModelHandler:
                                                            size=[batch_size],
                                                            dtype=torch.int64)
 
-    def _parse_model_requests(self, model_requests: List[Dict[str, Any]]) -> Tuple[List[str], Dict[str, Any]]:
+    def _parse_model_requests(
+        self,
+        model_requests: List[Dict[str,
+                                  Any]]) -> Tuple[List[str], Dict[str, Any]]:
         """Splits model requests into a flat list of inputs and merged kwargs."""
         generate_inputs = []
         generate_kwargs = {}
         for req in model_requests:
-            generate_input, generate_kwarg = self._parse_model_request(
-                req)
+            generate_input, generate_kwarg = self._parse_model_request(req)
             generate_inputs += [generate_input]
 
             for k, v in generate_kwarg.items():

--- a/examples/inference-deployments/mpt/mpt_7b_ft_handler.py
+++ b/examples/inference-deployments/mpt/mpt_7b_ft_handler.py
@@ -9,8 +9,9 @@ from typing import Dict, List, Tuple
 
 import torch
 from FasterTransformer.examples.pytorch.gpt.utils.parallel_gpt import \
-    ParallelGPT
-from scripts.inference.convert_hf_mpt_to_ft import convert_mpt_to_ft
+    ParallelGPT  # pyright: ignore
+from scripts.inference.convert_hf_mpt_to_ft import \
+    convert_mpt_to_ft  # pyright: ignore
 from torch.nn.utils.rnn import pad_sequence
 from transformers import AutoTokenizer
 

--- a/examples/inference-deployments/mpt/mpt_7b_ft_handler.py
+++ b/examples/inference-deployments/mpt/mpt_7b_ft_handler.py
@@ -200,7 +200,7 @@ class MPTFTModelHandler:
                                                            size=[batch_size],
                                                            dtype=torch.int64)
 
-    def _parse_model_requests(self, model_requests: List[Dict[str, Any]]) -> Tuple[str, Dict[str, Any]]:
+    def _parse_model_requests(self, model_requests: List[Dict[str, Any]]) -> Tuple[List[str], Dict[str, Any]]:
         """Splits model requests into a flat list of inputs and merged kwargs."""
         generate_inputs = []
         generate_kwargs = {}

--- a/examples/inference-deployments/mpt/mpt_7b_handler.py
+++ b/examples/inference-deployments/mpt/mpt_7b_handler.py
@@ -20,7 +20,8 @@ class MPTModelHandler():
         'temperature': 0.8,
     }
 
-    INPUT_STRINGS_KEY = 'input_strings'
+    INPUT_KEY = 'input'
+    PARAMETERS_KEY = 'parameters'
 
     def __init__(self, model_name: str):
         self.device = torch.cuda.current_device()
@@ -45,21 +46,20 @@ class MPTModelHandler():
                                   tokenizer=tokenizer,
                                   device=self.device)
 
-    def _parse_inputs(self, inputs: Dict[str, Any]):
-        if 'input_strings' not in inputs:
+    def _parse_model_request(self, model_request: Dict[str, Any]):
+        if self.INPUT_KEY not in model_request:
             raise RuntimeError(
-                'Input strings must be provided as a list to generate call')
+                f"{self.INPUT_KEY} must be provided to generate call")
 
-        generate_input = inputs[self.INPUT_STRINGS_KEY]
+        generate_input = model_request[self.INPUT_KEY]
 
         # Set default generate kwargs
         generate_kwargs = copy.deepcopy(self.DEFAULT_GENERATE_KWARGS)
         generate_kwargs['eos_token_id'] = self.tokenizer.eos_token_id
 
         # If request contains any additional kwargs, add them to generate_kwargs
-        for k, v in inputs.items():
-            if k not in [self.INPUT_STRINGS_KEY]:
-                generate_kwargs[k] = v
+        for k, v in model_request.get(self.PARAMETERS_KEY, {}).items():
+            generate_kwargs[k] = v
 
         return generate_input, generate_kwargs
 
@@ -70,19 +70,19 @@ class MPTModelHandler():
             output_list.append(output_bytes)
         return output_list
 
-    def predict(self, input_dicts: List[Dict[str, Any]]):
+    def predict(self, model_requests: List[Dict[str, Any]]):
         """Runs forward pass with the given inputs.
 
-        input_dicts: List of dictionaries that contain forward pass inputs as well
+        model_requests: List of dictionaries that contain forward pass inputs as well
         as other parameters, such as generate kwargs.
 
-        ex. [{'input': {'input_strings': ['hello world!']}}]
+        ex. [{'input': 'hello world!', 'parameters': {'max_length': 10}]
         """
         generate_inputs = []
         generate_kwargs = {}
         # Currently assumes the same generate_kwargs for the entire batch.
-        for input_dict in input_dicts:
-            generate_input, generate_kwargs = self._parse_inputs(input_dict)
+        for req in model_requests:
+            generate_input, generate_kwargs = self._parse_model_request(req)
             generate_inputs += generate_input
 
         print('Logging input to generate: ', generate_inputs)
@@ -90,7 +90,7 @@ class MPTModelHandler():
         return self._extract_output(outputs)
 
     def predict_stream(self, **inputs: Dict[str, Any]):
-        generate_input, generate_kwargs = self._parse_inputs(inputs)
+        generate_input, generate_kwargs = self._parse_model_request(inputs)
 
         # TextGenerationPipeline passes streamer to generate as a kwarg
         streamer = TextIteratorStreamer(self.tokenizer)

--- a/examples/inference-deployments/mpt/mpt_7b_handler.py
+++ b/examples/inference-deployments/mpt/mpt_7b_handler.py
@@ -49,7 +49,7 @@ class MPTModelHandler():
     def _parse_model_request(self, model_request: Dict[str, Any]):
         if self.INPUT_KEY not in model_request:
             raise RuntimeError(
-                f"{self.INPUT_KEY} must be provided to generate call")
+                f'{self.INPUT_KEY} must be provided to generate call')
 
         generate_input = model_request[self.INPUT_KEY]
 

--- a/examples/inference-deployments/mpt/mpt_7b_handler.py
+++ b/examples/inference-deployments/mpt/mpt_7b_handler.py
@@ -46,10 +46,10 @@ class MPTModelHandler():
                                   tokenizer=tokenizer,
                                   device=self.device)
 
-    def _parse_model_request(self, model_request: Dict[str, Any]):
+    def _parse_model_request(self, model_request: Dict):
         if self.INPUT_KEY not in model_request:
             raise RuntimeError(
-                f'{self.INPUT_KEY} must be provided to generate call')
+                f'"{self.INPUT_KEY}" must be provided to generate call')
 
         generate_input = model_request[self.INPUT_KEY]
 
@@ -70,7 +70,7 @@ class MPTModelHandler():
             output_list.append(output_bytes)
         return output_list
 
-    def predict(self, model_requests: List[Dict[str, Any]]):
+    def predict(self, model_requests: List[Dict]):
         """Runs forward pass with the given inputs.
 
         model_requests: List of dictionaries that contain forward pass inputs as well
@@ -89,7 +89,7 @@ class MPTModelHandler():
         outputs = self.generator(generate_inputs, **generate_kwargs)
         return self._extract_output(outputs)
 
-    def predict_stream(self, **inputs: Dict[str, Any]):
+    def predict_stream(self, **inputs: Dict):
         generate_input, generate_kwargs = self._parse_model_request(inputs)
 
         # TextGenerationPipeline passes streamer to generate as a kwarg

--- a/examples/inference-deployments/mpt/mpt_7b_handler.py
+++ b/examples/inference-deployments/mpt/mpt_7b_handler.py
@@ -83,7 +83,7 @@ class MPTModelHandler():
         # Currently assumes the same generate_kwargs for the entire batch.
         for req in model_requests:
             generate_input, generate_kwargs = self._parse_model_request(req)
-            generate_inputs += generate_input
+            generate_inputs += [generate_input]
 
         print('Logging input to generate: ', generate_inputs)
         outputs = self.generator(generate_inputs, **generate_kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 [tool.isort]
 multi_line_output = 0
 line_length = 80
-skip = [ "env", "wandb", "runs", "build", "node_modules" ]
+skip = [ "env", "wandb", "runs", "build", "node_modules", "examples/inference-deployments/mpt/mpt_7b_ft_handler.py" ]
 
 # Pyright
 [tool.pyright]


### PR DESCRIPTION
The new list of inputs passed to the handler are of the following structure dependent on this PR https://github.com/mosaicml/mcloud/pull/1589:
```
[
  {
    "input": <str/int/whatever>,
    "parameters": Dict
  },
  {
    "input": <str/int/whatever>,
    "parameters": Dict
  },
]
```

Also in this PR: renamed `inputs` to `model_requests`

handlers tested with different parameters and work:
`mpt_7b_handler.py`
not tested:
`mpt_7b_ft_handler.py`
can't test:
`instuctor_handler.py`