### PR TITLE
Fix mpt 7b yamls

### DIFF
--- a/examples/inference-deployments/mpt/mpt_7b.yaml
+++ b/examples/inference-deployments/mpt/mpt_7b.yaml
@@ -14,6 +14,6 @@ integrations:
 model:
   download_parameters:
     hf_path: mosaicml/mpt-7b
-  model_handler: examples.inference-deployments.mpt.mpt_handler.MPTModelHandler
+  model_handler: examples.inference-deployments.mpt.mpt_7b_handler.MPTModelHandler
   model_parameters:
     model_name: mosaicml/mpt-7b

--- a/examples/inference-deployments/mpt/mpt_7b_instruct.yaml
+++ b/examples/inference-deployments/mpt/mpt_7b_instruct.yaml
@@ -14,6 +14,6 @@ integrations:
 model:
   download_parameters:
     hf_path: mosaicml/mpt-7b-instruct
-  model_handler: examples.inference-deployments.mpt.mpt_handler.MPTModelHandler
+  model_handler: examples.inference-deployments.mpt.mpt_7b_handler.MPTModelHandler
   model_parameters:
     model_name: mosaicml/mpt-7b-instruct

--- a/examples/inference-deployments/mpt/mpt_7b_instruct_ft.yaml
+++ b/examples/inference-deployments/mpt/mpt_7b_instruct_ft.yaml
@@ -16,10 +16,10 @@ integrations:
   ssh_clone: false
 model:
   backend: faster_transformers
-  downloader: examples.inference-deployments.mpt.mpt_ft_handler.download_convert
+  downloader: examples.inference-deployments.mpt.mpt_7b_ft_handler.download_convert
   download_parameters:
     hf_path: mosaicml/mpt-7b-instruct
-  model_handler: examples.inference-deployments.mpt.mpt_ft_handler.MPTFTModelHandler
+  model_handler: examples.inference-deployments.mpt.mpt_7b_ft_handler.MPTFTModelHandler
   model_parameters:
     model_name_or_path: mosaicml/mpt-7b-instruct
     ft_lib_path: /code/FasterTransformer/build/lib/libth_transformer.so

--- a/examples/inference-deployments/mpt/mpt_7b_storywriter.yaml
+++ b/examples/inference-deployments/mpt/mpt_7b_storywriter.yaml
@@ -14,6 +14,6 @@ integrations:
 model:
   download_parameters:
     hf_path: mosaicml/mpt-7b-storywriter
-  model_handler: examples.inference-deployments.mpt.mpt_handler.MPTModelHandler
+  model_handler: examples.inference-deployments.mpt.mpt_7b_handler.MPTModelHandler
   model_parameters:
     model_name: mosaicml/mpt-7b-storywriter


### PR DESCRIPTION
We added commit hashes so that we don't need to change existing 7b yamls but then we changed the handler name for them. These are currently broken because the deployment keeps searching for mpt_handler and can't find it, because the commit hash has mpt_7b_handler and not mpt_handler. These changes were made in https://github.com/mosaicml/examples/pull/390