### PR TITLE
Add secrets check as part of pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,3 +88,12 @@ repos:
     entry: yamllint
     language: python
     types: [file, yaml]
+- repo: https://github.com/trufflesecurity/trufflehog.git
+  rev: v3.40.0
+  hooks:
+  - id: trufflehog
+    name: secret scan
+    entry: trufflehog filesystem ./
+    args:
+    - --only-verified
+    - --fail


### PR DESCRIPTION
# What does this PR do?
- Add secrets check as part of pre-commit.
- The `pre-commit run` command would fail if there is a verified secret leak. 

# What issue(s) does this change relate to?
CO-2201