### PR TITLE
Updated inference mpt yaml with new git commit and corrected handler name

### DIFF
--- a/examples/end-to-end-examples/stable_diffusion_dreambooth/generate.ipynb
+++ b/examples/end-to-end-examples/stable_diffusion_dreambooth/generate.ipynb
@@ -1,113 +1,113 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from omegaconf import OmegaConf\n",
-    "from model import build_stable_diffusion_model\n",
-    "import torch\n",
-    "import torchvision.transforms.functional as F\n",
-    "from torchvision.utils import make_grid"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "config_path = 'yamls/dreambooth.yaml' # to load the correct model architecture\n",
-    "checkpoint_path = '' # path to checkpoint\n",
-    "# optionally set to mps for local inference on m1 macs\n",
-    "device = 'cuda' if torch.cuda.is_available() else 'cpu' "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "config = OmegaConf.load(config_path)\n",
-    "model = build_stable_diffusion_model(\n",
-    "    model_name_or_path=config.model.name)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "checkpoint = torch.load()\n",
-    "model.load_state_dict(checkpoint['state']['model'])\n",
-    "model.to(device);"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Set prompt"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "prompt = 'An oil painting of sks dog in space on a starship'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "prompt = 'An oil painting of sks dog in space on a starship'\n",
-    "out = model.generate(prompt=prompt, num_images_per_prompt=1, seed=1337)\n",
-    "out = F.to_pil_image(make_grid(out))\n",
-    "out"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "out = model.generate(prompt=prompt, num_images_per_prompt=1, seed=1337, guidance_scale=20)\n",
-    "out = F.to_pil_image(make_grid(out))\n",
-    "out"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.10"
-  },
-  "orig_nbformat": 4
- },
- "nbformat": 4,
- "nbformat_minor": 2
+    "cells": [
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "from omegaconf import OmegaConf\n",
+                "from model import build_stable_diffusion_model\n",
+                "import torch\n",
+                "import torchvision.transforms.functional as F\n",
+                "from torchvision.utils import make_grid"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "config_path = 'yamls/dreambooth.yaml' # to load the correct model architecture\n",
+                "checkpoint_path = '' # path to checkpoint\n",
+                "# optionally set to mps for local inference on m1 macs\n",
+                "device = 'cuda' if torch.cuda.is_available() else 'cpu' "
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "config = OmegaConf.load(config_path)\n",
+                "model = build_stable_diffusion_model(\n",
+                "    model_name_or_path=config.model.name)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "checkpoint = torch.load()\n",
+                "model.load_state_dict(checkpoint['state']['model'])\n",
+                "model.to(device);"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "# Set prompt"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "prompt = 'An oil painting of sks dog in space on a starship'"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "prompt = 'An oil painting of sks dog in space on a starship'\n",
+                "out = model.generate(prompt=prompt, num_images_per_prompt=1, seed=1337)\n",
+                "out = F.to_pil_image(make_grid(out))\n",
+                "out"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "out = model.generate(prompt=prompt, num_images_per_prompt=1, seed=1337, guidance_scale=20)\n",
+                "out = F.to_pil_image(make_grid(out))\n",
+                "out"
+            ]
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.10.10"
+        },
+        "orig_nbformat": 4
+    },
+    "nbformat": 4,
+    "nbformat_minor": 2
 }

--- a/examples/inference-deployments/mpt/mpt_30b_ft.yaml
+++ b/examples/inference-deployments/mpt/mpt_30b_ft.yaml
@@ -9,7 +9,7 @@ command: |
 integrations:
 - integration_type: git_repo
   git_repo: mosaicml/examples
-  git_commit: d1cd9293b3eb943d38e912a3b9f4abd8bad52b5b
+  git_commit: df65ce9448f2e4c7803f7082930f80c8dc4e8fe1
   ssh_clone: false
 - integration_type: git_repo
   git_repo: mosaicml/llm-foundry

--- a/examples/inference-deployments/mpt/mpt_30b_ft.yaml
+++ b/examples/inference-deployments/mpt/mpt_30b_ft.yaml
@@ -2,7 +2,7 @@ name: mpt-30b-ft
 compute:
   gpus: 2
   gpu_type: a100_40gb
-image: mosaicml/inference:0.1.4
+image: mosaicml/inference:0.1.16
 replicas: 1
 command: |
   export PYTHONPATH=/code/llm-foundry:/code/examples:/code

--- a/examples/inference-deployments/mpt/mpt_30b_instruct_ft.yaml
+++ b/examples/inference-deployments/mpt/mpt_30b_instruct_ft.yaml
@@ -9,7 +9,7 @@ command: |
 integrations:
 - integration_type: git_repo
   git_repo: mosaicml/examples
-  git_commit: d1cd9293b3eb943d38e912a3b9f4abd8bad52b5b
+  git_commit: df65ce9448f2e4c7803f7082930f80c8dc4e8fe1
   ssh_clone: false
 - integration_type: git_repo
   git_repo: mosaicml/llm-foundry

--- a/examples/inference-deployments/mpt/mpt_30b_instruct_ft.yaml
+++ b/examples/inference-deployments/mpt/mpt_30b_instruct_ft.yaml
@@ -2,7 +2,7 @@ name: mpt-30b-instruct-ft
 compute:
   gpus: 2
   gpu_type: a100_40gb
-image: mosaicml/inference:0.1.4
+image: mosaicml/inference:0.1.16
 replicas: 1
 command: |
   export PYTHONPATH=/code/llm-foundry:/code/examples:/code

--- a/examples/inference-deployments/mpt/mpt_7b.yaml
+++ b/examples/inference-deployments/mpt/mpt_7b.yaml
@@ -2,7 +2,7 @@ name: mpt-7b
 compute:
   gpus: 1
   instance: oci.vm.gpu.a10.1
-image: mosaicml/inference:0.1.1
+image: mosaicml/inference:0.1.16
 replicas: 1
 command: |
   export PYTHONPATH=$PYTHONPATH:/code/examples

--- a/examples/inference-deployments/mpt/mpt_7b.yaml
+++ b/examples/inference-deployments/mpt/mpt_7b.yaml
@@ -10,7 +10,7 @@ integrations:
 - integration_type: git_repo
   git_repo: mosaicml/examples
   ssh_clone: false
-  git_commit: d1cd9293b3eb943d38e912a3b9f4abd8bad52b5b
+  git_commit: df65ce9448f2e4c7803f7082930f80c8dc4e8fe1
 model:
   download_parameters:
     hf_path: mosaicml/mpt-7b

--- a/examples/inference-deployments/mpt/mpt_7b.yaml
+++ b/examples/inference-deployments/mpt/mpt_7b.yaml
@@ -10,10 +10,10 @@ integrations:
 - integration_type: git_repo
   git_repo: mosaicml/examples
   ssh_clone: false
-  git_commit: dcc4c4dff002d282a2f432ccfcab4b61dc6a53af
+  git_commit: d1cd9293b3eb943d38e912a3b9f4abd8bad52b5b
 model:
   download_parameters:
     hf_path: mosaicml/mpt-7b
-  model_handler: examples.inference-deployments.mpt.mpt_7b_handler.MPTModelHandler
+  model_handler: examples.inference-deployments.mpt.mpt_handler.MPTModelHandler
   model_parameters:
     model_name: mosaicml/mpt-7b

--- a/examples/inference-deployments/mpt/mpt_7b_instruct.yaml
+++ b/examples/inference-deployments/mpt/mpt_7b_instruct.yaml
@@ -10,7 +10,7 @@ integrations:
 - integration_type: git_repo
   git_repo: mosaicml/examples
   ssh_clone: false
-  git_commit: d1cd9293b3eb943d38e912a3b9f4abd8bad52b5b
+  git_commit: df65ce9448f2e4c7803f7082930f80c8dc4e8fe1
 model:
   download_parameters:
     hf_path: mosaicml/mpt-7b-instruct

--- a/examples/inference-deployments/mpt/mpt_7b_instruct.yaml
+++ b/examples/inference-deployments/mpt/mpt_7b_instruct.yaml
@@ -10,10 +10,10 @@ integrations:
 - integration_type: git_repo
   git_repo: mosaicml/examples
   ssh_clone: false
-  git_commit: dcc4c4dff002d282a2f432ccfcab4b61dc6a53af
+  git_commit: d1cd9293b3eb943d38e912a3b9f4abd8bad52b5b
 model:
   download_parameters:
     hf_path: mosaicml/mpt-7b-instruct
-  model_handler: examples.inference-deployments.mpt.mpt_7b_handler.MPTModelHandler
+  model_handler: examples.inference-deployments.mpt.mpt_handler.MPTModelHandler
   model_parameters:
     model_name: mosaicml/mpt-7b-instruct

--- a/examples/inference-deployments/mpt/mpt_7b_instruct.yaml
+++ b/examples/inference-deployments/mpt/mpt_7b_instruct.yaml
@@ -2,7 +2,7 @@ name: mpt-7b-instruct
 compute:
   gpus: 1
   instance: oci.vm.gpu.a10.1
-image: mosaicml/inference:0.1.1
+image: mosaicml/inference:0.1.16
 replicas: 1
 command: |
   export PYTHONPATH=$PYTHONPATH:/code/examples

--- a/examples/inference-deployments/mpt/mpt_7b_instruct_ft.yaml
+++ b/examples/inference-deployments/mpt/mpt_7b_instruct_ft.yaml
@@ -2,7 +2,7 @@ name: mpt-7b-instruct-ft
 compute:
   gpus: 1
   instance: oci.vm.gpu.a10.1
-image: mosaicml/inference:0.1.1
+image: mosaicml/inference:0.1.16
 replicas: 1
 command: |
   export PYTHONPATH=/code/llm-foundry:/code/examples:/code

--- a/examples/inference-deployments/mpt/mpt_7b_instruct_ft.yaml
+++ b/examples/inference-deployments/mpt/mpt_7b_instruct_ft.yaml
@@ -9,7 +9,7 @@ command: |
 integrations:
 - integration_type: git_repo
   git_repo: mosaicml/examples
-  git_commit: d1cd9293b3eb943d38e912a3b9f4abd8bad52b5b
+  git_commit: df65ce9448f2e4c7803f7082930f80c8dc4e8fe1
   ssh_clone: false
 - integration_type: git_repo
   git_repo: mosaicml/llm-foundry

--- a/examples/inference-deployments/mpt/mpt_7b_storywriter.yaml
+++ b/examples/inference-deployments/mpt/mpt_7b_storywriter.yaml
@@ -10,7 +10,7 @@ integrations:
 - integration_type: git_repo
   git_repo: mosaicml/examples
   ssh_clone: false
-  git_commit: dcc4c4dff002d282a2f432ccfcab4b61dc6a53af
+  git_commit: d1cd9293b3eb943d38e912a3b9f4abd8bad52b5b
 model:
   download_parameters:
     hf_path: mosaicml/mpt-7b-storywriter

--- a/examples/inference-deployments/mpt/mpt_7b_storywriter.yaml
+++ b/examples/inference-deployments/mpt/mpt_7b_storywriter.yaml
@@ -2,7 +2,7 @@ name: mpt-7b-storywriter
 compute:
   gpus: 1
   instance: oci.vm.gpu.a10.1
-image: mosaicml/inference:0.1.1
+image: mosaicml/inference:0.1.16
 replicas: 1
 command: |
   export PYTHONPATH=$PYTHONPATH:/code/examples

--- a/examples/inference-deployments/mpt/mpt_7b_storywriter.yaml
+++ b/examples/inference-deployments/mpt/mpt_7b_storywriter.yaml
@@ -10,7 +10,7 @@ integrations:
 - integration_type: git_repo
   git_repo: mosaicml/examples
   ssh_clone: false
-  git_commit: d1cd9293b3eb943d38e912a3b9f4abd8bad52b5b
+  git_commit: df65ce9448f2e4c7803f7082930f80c8dc4e8fe1
 model:
   download_parameters:
     hf_path: mosaicml/mpt-7b-storywriter


### PR DESCRIPTION
Confirmed with a test deploy by using mpt_7b_instruct_ft.yaml with gcp_path

```
2023-07-24 13:56 ❯ mcli get deployment logs mpt-7b-instruct-ft-5a2e3q
Cloning into 'examples'...
Note: switching to 'd1cd9293b3eb943d38e912a3b9f4abd8bad52b5b'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at d1cd929 Add GCP downloader in example (#419)
/code
Cloning into 'llm-foundry'...
Note: switching to '496b50bd588b1a7231fe54b05d70babb3620fc72'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 496b50b Add trust remote code for tokenizer in inference conversion script (#446)
/code
/code/FasterTransformer/examples/pytorch/gpt/utils/gpt.py:221: SyntaxWarning: assertion is always true, perhaps remove parentheses?
  assert(self.pre_embed_idx < self.post_embed_idx, "Pre decoder embedding index should be lower than post decoder embedding index.")
Downloading model from path: gs://mosaicml-mcloud-tests/sg_test
Downloading /tmp/mpt/local_model/checkpoints-1671246524-rare-albatross-ep0-ba12-rank0.pt...
Converting model to FT format
Traceback (most recent call last):
  File "/code/inference_go/downloader.py", line 83, in <module>
    download_func(**model_config.download_parameters)
  File "/code/examples/examples/inference-deployments/mpt/mpt_ft_handler.py", line 122, in download_convert
    convert_mpt_to_ft(model_name_or_path, LOCAL_CHECKPOINT_DIR, gpus,
  File "/code/llm-foundry/scripts/inference/convert_hf_mpt_to_ft.py", line 200, in convert_mpt_to_ft
    model = transformers.AutoModelForCausalLM.from_pretrained(
  File "/usr/lib/python3/dist-packages/transformers/models/auto/auto_factory.py", line 441, in from_pretrained
    config, kwargs = AutoConfig.from_pretrained(
  File "/usr/lib/python3/dist-packages/transformers/models/auto/configuration_auto.py", line 908, in from_pretrained
    config_dict, unused_kwargs = PretrainedConfig.get_config_dict(pretrained_model_name_or_path, **kwargs)
  File "/usr/lib/python3/dist-packages/transformers/configuration_utils.py", line 573, in get_config_dict
    config_dict, kwargs = cls._get_config_dict(pretrained_model_name_or_path, **kwargs)
  File "/usr/lib/python3/dist-packages/transformers/configuration_utils.py", line 628, in _get_config_dict
    resolved_config_file = cached_file(
  File "/usr/lib/python3/dist-packages/transformers/utils/hub.py", line 380, in cached_file
    raise EnvironmentError(
OSError: /tmp/mpt/local_model does not appear to have a file named config.json. Checkout 'https://huggingface.co//tmp/mpt/local_model/None' for available files.
```