### PR TITLE
Refine llama2 handler

### DIFF
--- a/examples/inference-deployments/llama2/llama2_handler.py
+++ b/examples/inference-deployments/llama2/llama2_handler.py
@@ -75,7 +75,7 @@ class Llama2ModelHandler:
 
             # Deepspeed's init_inference takes in a huggingface model.
             ds_engine = deepspeed.init_inference(model, config=inf_config)
-            ds_model = ds_engine.module
+            self.ds_model = ds_engine.module
 
         # For some reason, we have to set device after the the deepspeed.onDevice block
         self.device = torch.cuda.current_device()

--- a/examples/inference-deployments/llama2/llama2_handler.py
+++ b/examples/inference-deployments/llama2/llama2_handler.py
@@ -80,7 +80,7 @@ class Llama2ModelHandler:
         # For some reason, we have to set device after the the deepspeed.onDevice block
         self.device = torch.cuda.current_device()
         self.generator = pipeline(task='text-generation',
-                                  model=ds_model,
+                                  model=self.ds_model,
                                   tokenizer=self.tokenizer,
                                   device=self.device)
 

--- a/examples/inference-deployments/llama2/llama2_handler.py
+++ b/examples/inference-deployments/llama2/llama2_handler.py
@@ -8,18 +8,23 @@ import os
 
 import deepspeed
 import torch
-from transformers import (AutoModelForCausalLM, AutoTokenizer,
-                          LlamaForCausalLM, LlamaConfig, LlamaTokenizer,
+from transformers import (LlamaForCausalLM, LlamaConfig, LlamaTokenizer,
                           TextIteratorStreamer, pipeline)
+
 
 class Llama2ModelHandler:
 
     DEFAULT_GENERATE_KWARGS = {
-        'max_length': 256,
+        'max_new_tokens': 64,
         'use_cache': True,
         'do_sample': True,
         'top_p': 0.95,
         'temperature': 0.8,
+    }
+
+    # A mapping from API parameter names to Llama2 model param names.
+    TRANSLATED_GENERATE_KWARGS = {
+        'max_length': 'max_new_tokens',
     }
 
     INPUT_KEY = 'input'
@@ -29,11 +34,14 @@ class Llama2ModelHandler:
     def __init__(
         self,
         model_name_or_path: str,
+        max_new_tokens: int = 0,
     ):
         super().__init__()
         self.model_name_or_path = model_name_or_path
+        self.max_new_tokens = max_new_tokens
         self.setup()
 
+    @torch.inference_mode()
     def setup(self):
         print(f"Loading Llama2 Model with name: {self.model_name_or_path}")
         hf_model_name = self.model_name_or_path
@@ -49,17 +57,23 @@ class Llama2ModelHandler:
         }
 
         with deepspeed.OnDevice(dtype=dtype, device='meta'):
-            model = LlamaForCausalLM.from_pretrained(hf_model_name, low_cpu_mem_usage=True)
-            hf_config = LlamaConfig.from_pretrained(hf_model_name, low_cpu_mem_usage=True)
-        
+            model = LlamaForCausalLM.from_pretrained(hf_model_name,
+                                                     low_cpu_mem_usage=True)
+            hf_config = LlamaConfig.from_pretrained(hf_model_name,
+                                                    low_cpu_mem_usage=True)
+
             print("Loaded model!")
 
             model.eval()
-        
-            self.tokenizer = LlamaTokenizer.from_pretrained(hf_model_name, low_cpu_mem_usage=True)
-        
-            # Deepspeed's init_inference takes in a huggingface model, which is the .model
-            # object of our ComposerModel object.
+
+            self.tokenizer = LlamaTokenizer.from_pretrained(
+                hf_model_name, low_cpu_mem_usage=True)
+            # Llama2 was trained with pad_token_id = -1 but we can't use that at inference time.
+            # See: github/transformers/docs/source/en/model_doc/llama2.md
+            # TODO: did HF add a '<pad>' token when they converted the checkpoint?
+            self.tokenizer.pad_token_id = 0  # make it different from the eos token
+
+            # Deepspeed's init_inference takes in a huggingface model.
             ds_engine = deepspeed.init_inference(model, config=inf_config)
             ds_model = ds_engine.module
 
@@ -83,17 +97,18 @@ class Llama2ModelHandler:
 
         # If request contains any additional kwargs, add them to generate_kwargs
         for k, v in model_request.get(self.PARAMETERS_KEY, {}).items():
+            k = self.TRANSLATED_GENERATE_KWARGS.get(k, k)
             generate_kwargs[k] = v
+
+        # This is a slow model so we support a global cap on max_new_tokens to minimize
+        # head-of-line blocking headaches.
+        if self.max_new_tokens > 0:
+            generate_kwargs['max_new_tokens'] = max(
+                1, min(generate_kwargs['max_new_tokens'], self.max_new_tokens))
 
         return generate_input, generate_kwargs
 
-    def _extract_output(self, outputs: List[Any]):
-        output_bytes_list = []
-        for output in outputs:
-            output_item = output[0]['generated_text']
-            output_bytes_list.append(output_item)
-        return output_bytes_list
-
+    @torch.inference_mode()
     def predict(self, model_requests: List[Dict[str, Any]]):
         """
         model_requests: List of dictionaries that contain forward pass inputs as well
@@ -107,9 +122,19 @@ class Llama2ModelHandler:
             generate_input, generate_kwargs = self._parse_model_request(req)
             generate_inputs += [generate_input]
 
-        outputs = self.generator(generate_inputs, **generate_kwargs)
-
-        return self._extract_output(outputs)
+        # Not using a HF pipeline here because that falls back to low-performance
+        # behaviour if you don't get all the args just right. Eg. serializes generate
+        # requests for every example in a batch.
+        batch = self.tokenizer(generate_inputs,
+                               return_tensors='pt',
+                               padding=True)
+        input_ids = batch.input_ids.to(f'cuda:{torch.cuda.current_device()}')
+        output_token_ids = self.ds_model.generate(input_ids, **generate_kwargs)
+        # TODO: do we need this synchronize?
+        torch.cuda.synchronize()
+        outputs = self.tokenizer.batch_decode(output_token_ids,
+                                              skip_special_tokens=True)
+        return outputs
 
     def predict_stream(self, **inputs):
         generate_input, generate_kwargs = self._parse_model_request(inputs)


### PR DESCRIPTION
Changes:
- Add `torch.inference_mode` decorators.
- Instead of using a `pipeline`, manually implement `tokenize -> generate`. The pipeline was serializing batches, giving us linearly increasing inference latency for batched requests.
- Additional logic around `max_new_tokens` (global cap, translation from `max_length`).