### PR TITLE
update mcloud yamls + requirements for sd and sd-dreambooth

### DIFF
--- a/examples/end-to-end-examples/stable_diffusion/requirements.txt
+++ b/examples/end-to-end-examples/stable_diffusion/requirements.txt
@@ -10,6 +10,7 @@ omegaconf==2.3.0
 # -------- diffusion -------- #
 diffusers[torch]==0.11.1
 transformers[torch]==4.25.1
+datasets>=2.14.6
 pydantic==1.10.10
 scipy==1.11.1
 

--- a/examples/end-to-end-examples/stable_diffusion/requirements.txt
+++ b/examples/end-to-end-examples/stable_diffusion/requirements.txt
@@ -10,7 +10,7 @@ omegaconf==2.3.0
 # -------- diffusion -------- #
 diffusers[torch]==0.11.1
 transformers[torch]==4.25.1
-datasets>=2.14.6
+datasets==2.14.6
 pydantic==1.10.10
 scipy==1.11.1
 

--- a/examples/end-to-end-examples/stable_diffusion/yamls/mcloud_run.yaml
+++ b/examples/end-to-end-examples/stable_diffusion/yamls/mcloud_run.yaml
@@ -10,11 +10,10 @@ compute:
 integrations:
 - integration_type: git_repo
   git_repo: mosaicml/examples
-  git_branch: v0.0.4
-  pip_install: .[stable-diffusion]
   ssh_clone: false
 command: |
   cd examples/examples/stable_diffusion
+  pip install -r requirements.txt
   composer main.py /mnt/config/parameters.yaml
 
 parameters:

--- a/examples/end-to-end-examples/stable_diffusion_dreambooth/requirements-cpu.txt
+++ b/examples/end-to-end-examples/stable_diffusion_dreambooth/requirements-cpu.txt
@@ -9,3 +9,5 @@ omegaconf
 # -------- diffusion -------- #
 diffusers[torch]==0.11.1
 transformers[torch]==4.25.1
+datasets>=2.14.6
+

--- a/examples/end-to-end-examples/stable_diffusion_dreambooth/requirements-cpu.txt
+++ b/examples/end-to-end-examples/stable_diffusion_dreambooth/requirements-cpu.txt
@@ -9,5 +9,5 @@ omegaconf
 # -------- diffusion -------- #
 diffusers[torch]==0.11.1
 transformers[torch]==4.25.1
-datasets>=2.14.6
+datasets==2.14.6
 

--- a/examples/end-to-end-examples/stable_diffusion_dreambooth/requirements-cpu.txt
+++ b/examples/end-to-end-examples/stable_diffusion_dreambooth/requirements-cpu.txt
@@ -10,4 +10,3 @@ omegaconf
 diffusers[torch]==0.11.1
 transformers[torch]==4.25.1
 datasets==2.14.6
-

--- a/examples/end-to-end-examples/stable_diffusion_dreambooth/requirements.txt
+++ b/examples/end-to-end-examples/stable_diffusion_dreambooth/requirements.txt
@@ -9,6 +9,7 @@ omegaconf
 # -------- diffusion -------- #
 diffusers[torch]==0.11.1
 transformers[torch]==4.25.1
+datasets>=2.14.6
 
 # -------- xformers -------- #
 xformers

--- a/examples/end-to-end-examples/stable_diffusion_dreambooth/requirements.txt
+++ b/examples/end-to-end-examples/stable_diffusion_dreambooth/requirements.txt
@@ -9,7 +9,7 @@ omegaconf
 # -------- diffusion -------- #
 diffusers[torch]==0.11.1
 transformers[torch]==4.25.1
-datasets>=2.14.6
+datasets==2.14.6
 
 # -------- xformers -------- #
 xformers

--- a/examples/end-to-end-examples/stable_diffusion_dreambooth/yamls/mcloud_run.yaml
+++ b/examples/end-to-end-examples/stable_diffusion_dreambooth/yamls/mcloud_run.yaml
@@ -10,11 +10,11 @@ compute:
 integrations:
 - integration_type: git_repo
   git_repo: mosaicml/examples
-  pip_install: .[stable-diffusion-dreambooth]
   ssh_clone: false
 
 command: |
   cd examples/examples/stable_diffusion_dreambooth
+  pip install -r requirements.txt
   composer main.py /mnt/config/parameters.yaml
 parameters:
   # Name of the  training run used for checkpointing and other logging


### PR DESCRIPTION
fsspec broke huggingface datasetes a few months back. updating datasets version in our requirements so these examples will run. Also updating the mcloud yaml to directly install requirements as it seems that the previous install reqs were broken during the re-org. 

hf datasetes issue: https://github.com/huggingface/datasets/issues/6352